### PR TITLE
Use global custom element mapping for all MDX pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -781,6 +781,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@mdx-js/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-7zlZDf5xmWH8I0kFE4DG91COOkxjaW9DX5f1HWztZpFcVua2gJgMYfIkFaDpO/DH/tWi6Mz+OheW4194r15igg==",
+      "dependencies": {
+        "@types/mdx": "^2.0.0",
+        "@types/react": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.2.tgz",
@@ -7644,6 +7660,7 @@
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@mdx-js/loader": "^2.1.1",
+        "@mdx-js/react": "^2.1.1",
         "@monaco-editor/react": "^4.4.5",
         "@mui/icons-material": "^5.6.2",
         "clsx": "^1.1.1",
@@ -8237,6 +8254,7 @@
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
         "@mdx-js/loader": "^2.1.1",
+        "@mdx-js/react": "*",
         "@monaco-editor/react": "^4.4.5",
         "@mui/icons-material": "^5.6.2",
         "@tailwindcss/aspect-ratio": "^0.4.0",
@@ -8328,6 +8346,15 @@
         "unist-util-stringify-position": "^3.0.0",
         "unist-util-visit": "^4.0.0",
         "vfile": "^5.0.0"
+      }
+    },
+    "@mdx-js/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-7zlZDf5xmWH8I0kFE4DG91COOkxjaW9DX5f1HWztZpFcVua2gJgMYfIkFaDpO/DH/tWi6Mz+OheW4194r15igg==",
+      "requires": {
+        "@types/mdx": "^2.0.0",
+        "@types/react": ">=16"
       }
     },
     "@monaco-editor/loader": {

--- a/packages/client/layouts/blog.tsx
+++ b/packages/client/layouts/blog.tsx
@@ -6,7 +6,6 @@ import { FC, useEffect, useState } from "react";
 import A from "@client/components/anchor";
 import Footer from "@client/components/footer";
 import HomeNavbar from "@client/components/home/navbar";
-import PostHeading from "@client/components/postHeading";
 
 import { BlogLayoutProps } from "@client/types/components.type";
 import { Author } from "@client/types/utils.type";
@@ -37,7 +36,7 @@ const AuthorCard: FC<Author> = ({ name, github }) => (
   </div>
 );
 
-const BlogLayout: FC<BlogLayoutProps> = ({ title, authors, timestamp, children: Content }) => {
+const BlogLayout: FC<BlogLayoutProps> = ({ title, authors, timestamp, children }) => {
   const [minutesToRead, setMinutesToRead] = useState(0);
   useEffect(() => {
     const wordCnt = document.getElementsByClassName("post")[0].textContent?.split(" ").length ?? 0;
@@ -73,17 +72,7 @@ const BlogLayout: FC<BlogLayoutProps> = ({ title, authors, timestamp, children: 
       <main className="px-6 sm:px-10">
         <article className="mx-auto my-[72px] max-w-prose post blog">
           <h1 className="hidden print:block">{title}</h1>
-          <Content
-            components={{
-              a: ({ ref, ...rest }) => <A {...rest} />,
-              h1: props => <PostHeading {...props} level={1} />,
-              h2: props => <PostHeading {...props} level={2} />,
-              h3: props => <PostHeading {...props} level={3} />,
-              h4: props => <PostHeading {...props} level={4} />,
-              h5: props => <PostHeading {...props} level={5} />,
-              h6: props => <PostHeading {...props} level={6} />,
-            }}
-          />
+          {children}
         </article>
       </main>
       <Footer className="px-6 sm:px-10" containerClasses="mx-auto w-full lg:w-5/6 xl:w-4/5" />

--- a/packages/client/layouts/blog.tsx
+++ b/packages/client/layouts/blog.tsx
@@ -1,4 +1,3 @@
-import { MDXProvider } from "@mdx-js/react";
 import { format } from "date-fns";
 import Head from "next/head";
 import Image from "next/image";
@@ -7,7 +6,6 @@ import { FC, useEffect, useState } from "react";
 import A from "@client/components/anchor";
 import Footer from "@client/components/footer";
 import HomeNavbar from "@client/components/home/navbar";
-import PostHeading from "@client/components/postHeading";
 
 import { BlogLayoutProps } from "@client/types/components.type";
 import { Author } from "@client/types/utils.type";
@@ -74,19 +72,7 @@ const BlogLayout: FC<BlogLayoutProps> = ({ title, authors, timestamp, children }
       <main className="px-6 sm:px-10">
         <article className="mx-auto my-[72px] max-w-prose post blog">
           <h1 className="hidden print:block">{title}</h1>
-          <MDXProvider
-            components={{
-              a: ({ ref, ...rest }) => <A {...rest} />,
-              h1: props => <PostHeading {...props} level={1} />,
-              h2: props => <PostHeading {...props} level={2} />,
-              h3: props => <PostHeading {...props} level={3} />,
-              h4: props => <PostHeading {...props} level={4} />,
-              h5: props => <PostHeading {...props} level={5} />,
-              h6: props => <PostHeading {...props} level={6} />,
-            }}
-          >
-            {children}
-          </MDXProvider>
+          {children}
         </article>
       </main>
       <Footer className="px-6 sm:px-10" containerClasses="mx-auto w-full lg:w-5/6 xl:w-4/5" />

--- a/packages/client/layouts/blog.tsx
+++ b/packages/client/layouts/blog.tsx
@@ -1,3 +1,4 @@
+import { MDXProvider } from "@mdx-js/react";
 import { format } from "date-fns";
 import Head from "next/head";
 import Image from "next/image";
@@ -6,6 +7,7 @@ import { FC, useEffect, useState } from "react";
 import A from "@client/components/anchor";
 import Footer from "@client/components/footer";
 import HomeNavbar from "@client/components/home/navbar";
+import PostHeading from "@client/components/postHeading";
 
 import { BlogLayoutProps } from "@client/types/components.type";
 import { Author } from "@client/types/utils.type";
@@ -72,7 +74,19 @@ const BlogLayout: FC<BlogLayoutProps> = ({ title, authors, timestamp, children }
       <main className="px-6 sm:px-10">
         <article className="mx-auto my-[72px] max-w-prose post blog">
           <h1 className="hidden print:block">{title}</h1>
-          {children}
+          <MDXProvider
+            components={{
+              a: ({ ref, ...rest }) => <A {...rest} />,
+              h1: props => <PostHeading {...props} level={1} />,
+              h2: props => <PostHeading {...props} level={2} />,
+              h3: props => <PostHeading {...props} level={3} />,
+              h4: props => <PostHeading {...props} level={4} />,
+              h5: props => <PostHeading {...props} level={5} />,
+              h6: props => <PostHeading {...props} level={6} />,
+            }}
+          >
+            {children}
+          </MDXProvider>
         </article>
       </main>
       <Footer className="px-6 sm:px-10" containerClasses="mx-auto w-full lg:w-5/6 xl:w-4/5" />

--- a/packages/client/next.config.mjs
+++ b/packages/client/next.config.mjs
@@ -38,6 +38,7 @@ const nextConfig = {
           /** @type {import("@mdx-js/loader").Options} */
           options: {
             rehypePlugins: [rehypeSlug],
+            providerImportSource: "@mdx-js/react",
           },
         },
       ],

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mdx-js/loader": "^2.1.1",
+    "@mdx-js/react": "^2.1.1",
     "@monaco-editor/react": "^4.4.5",
     "@mui/icons-material": "^5.6.2",
     "clsx": "^1.1.1",

--- a/packages/client/pages/_app.tsx
+++ b/packages/client/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { MDXProvider } from "@mdx-js/react";
 import { AppProps } from "next/app";
 
 import BreakpointContext from "@client/context/breakpoint";
@@ -6,6 +7,8 @@ import { useBreakpointInit } from "@client/hooks/breakpoint";
 import useNProgress from "@client/hooks/nprogress";
 import { useModeInit } from "@client/hooks/theme";
 
+import A from "@client/components/anchor";
+import PostHeading from "@client/components/postHeading";
 import { ErrorBoundary } from "@client/layouts/errors";
 
 import "@client/styles/globals.css";
@@ -18,7 +21,19 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ErrorBoundary>
       <ModeContext.Provider value={{ mode, setMode }}>
         <BreakpointContext.Provider value={breakpoint}>
-          <Component {...pageProps} />
+          <MDXProvider
+            components={{
+              a: ({ ref, ...rest }) => <A {...rest} />,
+              h1: props => <PostHeading {...props} level={1} />,
+              h2: props => <PostHeading {...props} level={2} />,
+              h3: props => <PostHeading {...props} level={3} />,
+              h4: props => <PostHeading {...props} level={4} />,
+              h5: props => <PostHeading {...props} level={5} />,
+              h6: props => <PostHeading {...props} level={6} />,
+            }}
+          >
+            <Component {...pageProps} />
+          </MDXProvider>
         </BreakpointContext.Provider>
       </ModeContext.Provider>
     </ErrorBoundary>

--- a/packages/client/pages/docs/[...slug].tsx
+++ b/packages/client/pages/docs/[...slug].tsx
@@ -1,20 +1,18 @@
 import * as runtime from "react/jsx-runtime";
 import { compile, nodeTypes, run } from "@mdx-js/mdx";
+import { useMDXComponents } from "@mdx-js/react";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Head from "next/head";
-import { ComponentProps, FC, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
 import remarkPrism from "remark-prism";
 
 import { filePaths, getFileData, navData } from "@client/lib/documentation";
 
-import A from "@client/components/anchor";
 import DocsBottomBar from "@client/components/docs/bottombar";
 import DocsSidebar from "@client/components/docs/sidebar";
-import PostHeading from "@client/components/postHeading";
 
-import { PostHeadingProps } from "@client/types/components.type";
 import { DocsData, NavData } from "@client/types/docs.type";
 
 type URLParams = { slug: string[] };
@@ -23,15 +21,12 @@ type PageProps = DocsData & {
   path: string[];
 };
 
-// `components` is just to avoid a warning when that prop is passed when MDX hasn't been rendered
-const Loading: FC<{ components: any }> = ({ components }) => <>Loading</>;
-
 const DocPage: NextPage<PageProps> = ({ title, content, lastModified, path, navData }) => {
   // Sorry for using any here, but since run() in @mdx-js/mdx returns Promise<any>, I can't do anything else.
   const [mdxModule, setMdxModule] = useState<any>(null);
-  const Content = mdxModule ? mdxModule.default : Loading;
+  const Content = mdxModule ? mdxModule.default : () => <>Loading</>;
   useEffect(() => {
-    (async () => setMdxModule(await run(content, runtime)))();
+    (async () => setMdxModule(await run(content, { ...runtime, useMDXComponents })))();
   }, [content]);
   return (
     <>
@@ -43,17 +38,7 @@ const DocPage: NextPage<PageProps> = ({ title, content, lastModified, path, navD
         <main className="col-span-full md:col-span-2 px-6 sm:px-12 py-12 max-w-prose">
           <div style={{ height: "60px" }} className="md:hidden" />
           <article className="post">
-            <Content
-              components={{
-                a: (props: ComponentProps<typeof A>) => <A {...props} />,
-                h1: (props: PostHeadingProps) => <PostHeading {...props} level={1} />,
-                h2: (props: PostHeadingProps) => <PostHeading {...props} level={2} />,
-                h3: (props: PostHeadingProps) => <PostHeading {...props} level={3} />,
-                h4: (props: PostHeadingProps) => <PostHeading {...props} level={4} />,
-                h5: (props: PostHeadingProps) => <PostHeading {...props} level={5} />,
-                h6: (props: PostHeadingProps) => <PostHeading {...props} level={6} />,
-              }}
-            />
+            <Content />
           </article>
           <hr />
           <DocsBottomBar lastModified={lastModified} path={path} />
@@ -81,6 +66,7 @@ const getStaticProps: GetStaticProps<PageProps, URLParams> = async ({ params }) 
             rehypeSlug,
           ],
           remarkPlugins: [remarkPrism],
+          providerImportSource: "@mdx-js/react",
         })
       ),
       path: params?.slug ?? [],

--- a/packages/client/pages/orbital/proposal.mdx
+++ b/packages/client/pages/orbital/proposal.mdx
@@ -1,12 +1,19 @@
 import authors from "@client/lib/authors";
 
 import BlogImage from "@client/components/blogImage";
+import BlogLayout from "@client/layouts/blog";
 
-export const meta = {
-  title: "Orbital 2022 Proposal",
-  authors: [authors.joulev, authors.vietanh],
-  timestamp: new Date("2022-03-14"),
-};
+export default function ({ children }) {
+  return (
+    <BlogLayout
+      title="Orbital 2022 Proposal"
+      authors={[authors.joulev, authors.vietanh]}
+      timestamp={new Date("2022-03-14")}
+    >
+      {children}
+    </BlogLayout>
+  );
+}
 
 ## Team Information
 

--- a/packages/client/pages/orbital/proposal.tsx
+++ b/packages/client/pages/orbital/proposal.tsx
@@ -1,9 +1,0 @@
-import { NextPage } from "next";
-
-import BlogLayout from "@client/layouts/blog";
-
-import Post, { meta } from "@client/markdown/orbital/proposal.mdx";
-
-const OrbitalProposal: NextPage = () => <BlogLayout {...meta}>{Post}</BlogLayout>;
-
-export default OrbitalProposal;

--- a/packages/client/types/components.type.ts
+++ b/packages/client/types/components.type.ts
@@ -1,4 +1,3 @@
-import { MDXProps } from "mdx/types";
 import { ComponentProps, MouseEventHandler, ReactNode } from "react";
 
 import { CurrentPage } from "./page.type";
@@ -21,7 +20,7 @@ export type BlogLayoutProps = {
     title: string;
     authors: Author[];
     timestamp: Date;
-    children: (props: MDXProps) => JSX.Element;
+    children: ReactNode;
 };
 
 export type BlogImageProps = {


### PR DESCRIPTION
* Now Markdown(X) files under `BlogLayout` can be used directly as Next.js pages. No need of an intermediate TSX file to import it.
* A same custom element mapping is used for all MDX pages, thanks to `@mdx-js/react`
* Using this template, we can now basically add Markdown pages to the app easily and quickly with various methods, whether by feeding as static files or having `next` generating the pages at build time. After spending at least 30 hours on various MDX-related packages and libraries during the last 6 months experimenting various ways to import and use Markdown, finally this day has come.