### PR TITLE
Remove ISR as capture-website is not working on serverless functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13651,6 +13651,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -14770,7 +14778,8 @@
         "react-string-replace": "^1.1.0",
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.0.1",
-        "remark-prism": "^1.3.6"
+        "remark-prism": "^1.3.6",
+        "swr": "^1.3.0"
       },
       "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.0",
@@ -15712,6 +15721,7 @@
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.0.1",
         "remark-prism": "^1.3.6",
+        "swr": "*",
         "tailwindcss": "^3.0.24",
         "typescript": "4.7.2"
       },
@@ -25295,6 +25305,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "swr": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "requires": {}
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15721,7 +15721,7 @@
         "rehype-raw": "^6.1.1",
         "rehype-slug": "^5.0.1",
         "remark-prism": "^1.3.6",
-        "swr": "*",
+        "swr": "^1.3.0",
         "tailwindcss": "^3.0.24",
         "typescript": "4.7.2"
       },

--- a/packages/client/__tests__/lib/getOgImage.test.ts
+++ b/packages/client/__tests__/lib/getOgImage.test.ts
@@ -40,15 +40,6 @@ describe("Test Opengraph image fetcher", () => {
         expect(temp).toBe("only run on Vercel");
     });
 
-    it("Should not create new file if it already exists", async () => {
-        process.env.VERCEL = "hello";
-        process.env.VERCEL_URL = "example.com";
-        fs.existsSync = jest.fn(() => true);
-        const temp = await getOgImage({});
-        expect(fs.existsSync).toHaveBeenCalledWith(`./public/images/og/${correctHash()}.png`);
-        expect(temp).toBe(correctURL());
-    });
-
     it("Should call correct URL to capture", async () => {
         process.env.VERCEL = "hello";
         process.env.VERCEL_URL = "example.com";

--- a/packages/client/lib/getOgImage.ts
+++ b/packages/client/lib/getOgImage.ts
@@ -12,29 +12,21 @@ export default async function getOgImage({ title, label }: OgImageProps) {
     const filePath = `${dir}/${hash}.png`;
     const publicPath = `https://${process.env.VERCEL_URL}/images/og/${hash}.png`;
 
-    if (existsSync(filePath)) {
-        console.log(`Getting image for "${title}" from cache successfully`);
-        return publicPath;
-    }
+    if (existsSync(filePath)) return publicPath;
 
     const url = new URL("https://ezkomment-67rtb9jff-joulev.vercel.app/opengraph");
     if (title) url.searchParams.append("title", title);
     if (label) url.searchParams.append("label", label);
 
-    try {
-        const buffer = await captureWebsite.buffer(url.href, {
-            width: 1200,
-            height: 630,
-            scaleFactor: 1,
-            // https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error
-            launchOptions: { args: ["--no-sandbox", "--disable-setuid-sandbox"] },
-        });
+    const buffer = await captureWebsite.buffer(url.href, {
+        width: 1200,
+        height: 630,
+        scaleFactor: 1,
+        // https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error
+        launchOptions: { args: ["--no-sandbox", "--disable-setuid-sandbox"] },
+    });
 
-        mkdirSync(dir, { recursive: true });
-        writeFileSync(filePath, buffer);
-        console.log(`Capturing image for "${title}" successfully`);
-    } catch (error) {
-        console.error(`Error while capturing image for "${title}":`, error);
-    }
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(filePath, buffer);
     return publicPath;
 }

--- a/packages/client/lib/getOgImage.ts
+++ b/packages/client/lib/getOgImage.ts
@@ -1,6 +1,6 @@
 import captureWebsite from "capture-website";
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, writeFileSync } from "fs";
 
 import { OgImageProps } from "@client/types/components.type";
 
@@ -11,8 +11,6 @@ export default async function getOgImage({ title, label }: OgImageProps) {
     const dir = `./public/images/og`;
     const filePath = `${dir}/${hash}.png`;
     const publicPath = `https://${process.env.VERCEL_URL}/images/og/${hash}.png`;
-
-    if (existsSync(filePath)) return publicPath;
 
     const url = new URL("https://ezkomment-67rtb9jff-joulev.vercel.app/opengraph");
     if (title) url.searchParams.append("title", title);

--- a/packages/client/lib/getOgImage.ts
+++ b/packages/client/lib/getOgImage.ts
@@ -12,21 +12,29 @@ export default async function getOgImage({ title, label }: OgImageProps) {
     const filePath = `${dir}/${hash}.png`;
     const publicPath = `https://${process.env.VERCEL_URL}/images/og/${hash}.png`;
 
-    if (existsSync(filePath)) return publicPath;
+    if (existsSync(filePath)) {
+        console.log(`Getting image for "${title}" from cache successfully`);
+        return publicPath;
+    }
 
     const url = new URL("https://ezkomment-67rtb9jff-joulev.vercel.app/opengraph");
     if (title) url.searchParams.append("title", title);
     if (label) url.searchParams.append("label", label);
 
-    const buffer = await captureWebsite.buffer(url.href, {
-        width: 1200,
-        height: 630,
-        scaleFactor: 1,
-        // https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error
-        launchOptions: { args: ["--no-sandbox", "--disable-setuid-sandbox"] },
-    });
+    try {
+        const buffer = await captureWebsite.buffer(url.href, {
+            width: 1200,
+            height: 630,
+            scaleFactor: 1,
+            // https://github.com/sindresorhus/capture-website#im-getting-a-sandbox-related-error
+            launchOptions: { args: ["--no-sandbox", "--disable-setuid-sandbox"] },
+        });
 
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(filePath, buffer);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(filePath, buffer);
+        console.log(`Capturing image for "${title}" successfully`);
+    } catch (error) {
+        console.error(`Error while capturing image for "${title}":`, error);
+    }
     return publicPath;
 }

--- a/packages/client/next.config.mjs
+++ b/packages/client/next.config.mjs
@@ -7,7 +7,7 @@ import remarkPrism from "remark-prism";
  */
 const nextConfig = {
   reactStrictMode: true,
-  pageExtensions: ["mdx", "tsx"],
+  pageExtensions: ["mdx", "tsx", "ts"],
   images: {
     domains: ["avatars.githubusercontent.com"],
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,7 +32,8 @@
     "react-string-replace": "^1.1.0",
     "rehype-raw": "^6.1.1",
     "rehype-slug": "^5.0.1",
-    "remark-prism": "^1.3.6"
+    "remark-prism": "^1.3.6",
+    "swr": "^1.3.0"
   },
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.4.0",

--- a/packages/client/pages/api/project-log/joulev.ts
+++ b/packages/client/pages/api/project-log/joulev.ts
@@ -1,0 +1,13 @@
+import { NextApiHandler } from "next";
+
+import getProjectLogJoulev from "@client/lib/orbital/logJoulev";
+
+import { ProjectLog } from "@client/types/utils.type";
+
+/**
+ * A wrapper to fetch the project log from Google Sheets. I don't want to expose the Google Sheets
+ * REST API path to client side.
+ */
+const handler: NextApiHandler<ProjectLog> = async (_, res) => res.json(await getProjectLogJoulev());
+
+export default handler;

--- a/packages/client/pages/orbital/index.tsx
+++ b/packages/client/pages/orbital/index.tsx
@@ -154,7 +154,7 @@ const OrbitalHome: NextPage<Props> = ({ seo }) => {
               title={<>Vu Van Dung&apos;s Project&nbsp;Log</>}
               href="/orbital/log-joulev"
               icon={ArticleOutlinedIcon}
-              date="updated daily"
+              date="automatically updated"
             />
             <SectionLink
               title={<>Nguyen Viet Anh&apos;s Project&nbsp;Log</>}

--- a/packages/client/pages/orbital/log-joulev.tsx
+++ b/packages/client/pages/orbital/log-joulev.tsx
@@ -116,7 +116,7 @@ const ProjectLogJoulev: NextPageWithLayout<Props> = ({ data: prefetch }) => {
       <div>
         <div className="border rounded border-card bg-card p-6 max-w-fit mx-auto">
           <div className="text-lg text-muted">Total hours spent</div>
-          <div className="text-3xl text-center">{data?.total ?? "loading"}</div>
+          <div className="text-3xl text-center">{(data ?? prefetch).total}</div>
         </div>
       </div>
       <div className="overflow-x-scroll -my-3">
@@ -125,7 +125,7 @@ const ProjectLogJoulev: NextPageWithLayout<Props> = ({ data: prefetch }) => {
           <div className="col-span-8 font-bold p-3">Content</div>
           <div className="col-span-1 font-bold p-3">Hrs</div>
           <div className="col-span-12 font-bold p-3 pr-0">Remarks</div>
-          {(data?.logs ?? []).map(({ time, content, hours, remarks }, index) => (
+          {(data ?? prefetch).logs.map(({ time, content, hours, remarks }, index) => (
             <Fragment key={index}>
               <div className="col-span-3 p-3 border-t border-card pl-0">
                 <TableTime time={time} />

--- a/packages/client/pages/orbital/log-joulev.tsx
+++ b/packages/client/pages/orbital/log-joulev.tsx
@@ -1,8 +1,8 @@
 import clsx from "clsx";
-import { format, parseISO } from "date-fns";
 import { GetStaticProps } from "next";
 import { FC, Fragment, ReactNode, ReactNodeArray } from "react";
 import reactStringReplace from "react-string-replace";
+import useSWR from "swr";
 
 import getOgImage from "@client/lib/getOgImage";
 import getProjectLogJoulev from "@client/lib/orbital/logJoulev";
@@ -18,7 +18,6 @@ import { NextPageWithLayout } from "@client/types/utils.type";
 import authors from "@client/constants/authors";
 
 type Props = {
-  lastUpdated: string;
   data: ProjectLog;
   seo: SeoProps;
 };
@@ -88,72 +87,67 @@ const TableRemarks: FC<{ remarks: string }> = ({ remarks }) => {
   return <>{new ReplaceableReact(remarks).replaceAll()}</>;
 };
 
-const ProjectLogJoulev: NextPageWithLayout<Props> = ({ lastUpdated, data }) => (
-  <div className="flex flex-col gap-18">
-    <div className="max-w-prose mx-auto">
-      <Banner variant="warning" className="lg:hidden mb-6">
-        It is recommended to view this page in a wider screen.
-      </Banner>
-      <p>
-        This notes all activities that Vu Van Dung (<A href="https://github.com/joulev">@joulev</A>)
-        does on the ezkomment project from the day it commences (12 March &ndash; the date of the
-        first commit). Since all activities from 12 March to 7 May are not properly logged as they
-        are done, the time spent on studying and playing with new technologies, as well as the time
-        to make small fixes and improvements have to be merged to one entry. All other entries also
-        have to be derived from the commit history.
-      </p>
-      <p>All activities from 7 May onwards are properly logged as they are done.</p>
-      <p>
-        Since the two project member live about 300km from each other during the summer,{" "}
-        <abbr title="face-to-face">F2F</abbr> is not possible, and we choose instant messaging for
-        all communications. Therefore during the summer, we have no direct meetings, whether online
-        or offline, between the members.
-      </p>
-      <p className="text-muted mb-0">
-        This page is{" "}
-        <A href="https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration">
-          updated daily
-        </A>
-        . Last updated at{" "}
-        <time title={lastUpdated} className="font-bold">
-          {format(parseISO(lastUpdated), "d MMMM y HH:mm:ss")}
-        </time>
-        .
-      </p>
-    </div>
-    <div>
-      <div className="border rounded border-card bg-card p-6 max-w-fit mx-auto">
-        <div className="text-lg text-muted">Total hours spent</div>
-        <div className="text-3xl text-center">{data.total}</div>
+const ProjectLogJoulev: NextPageWithLayout<Props> = ({ data: prefetch }) => {
+  const fetcher = (url: string) => fetch(url).then(res => res.json()) as Promise<ProjectLog>;
+  const { data } = useSWR("/api/project-log/joulev", fetcher, { fallbackData: prefetch });
+  return (
+    <div className="flex flex-col gap-18">
+      <div className="max-w-prose mx-auto">
+        <Banner variant="warning" className="lg:hidden mb-6">
+          It is recommended to view this page in a wider screen.
+        </Banner>
+        <p>
+          This notes all activities that Vu Van Dung (
+          <A href="https://github.com/joulev">@joulev</A>) does on the ezkomment project from the
+          day it commences (12 March &ndash; the date of the first commit). Since all activities
+          from 12 March to 7 May are not properly logged as they are done, the time spent on
+          studying and playing with new technologies, as well as the time to make small fixes and
+          improvements have to be merged to one entry. All other entries also have to be derived
+          from the commit history.
+        </p>
+        <p>All activities from 7 May onwards are properly logged as they are done.</p>
+        <p className="mb-0">
+          Since the two project member live about 300km from each other during the summer,{" "}
+          <abbr title="face-to-face">F2F</abbr> is not possible, and we choose instant messaging for
+          all communications. Therefore during the summer, we have no direct meetings, whether
+          online or offline, between the members.
+        </p>
+      </div>
+      <div>
+        <div className="border rounded border-card bg-card p-6 max-w-fit mx-auto">
+          <div className="text-lg text-muted">Total hours spent</div>
+          <div className="text-3xl text-center">{data?.total ?? "loading"}</div>
+        </div>
+      </div>
+      <div className="overflow-x-scroll -my-3">
+        <div className="grid grid-cols-24">
+          <div className="col-span-3 font-bold p-3 pl-0">Dates (D/M)</div>
+          <div className="col-span-8 font-bold p-3">Content</div>
+          <div className="col-span-1 font-bold p-3">Hrs</div>
+          <div className="col-span-12 font-bold p-3 pr-0">Remarks</div>
+          {(data?.logs ?? []).map(({ time, content, hours, remarks }, index) => (
+            <Fragment key={index}>
+              <div className="col-span-3 p-3 border-t border-card pl-0">
+                <TableTime time={time} />
+              </div>
+              <div className="col-span-8 p-3 border-t border-card">
+                <TableContent content={content} />
+              </div>
+              <div className="col-span-1 p-3 border-t border-card">{hours}</div>
+              <div className="col-span-12 p-3 border-t border-card pr-0">
+                <TableRemarks remarks={remarks} />
+              </div>
+            </Fragment>
+          ))}
+        </div>
       </div>
     </div>
-    <div className="overflow-x-scroll -my-3">
-      <div className="grid grid-cols-24">
-        <div className="col-span-3 font-bold p-3 pl-0">Dates (D/M)</div>
-        <div className="col-span-8 font-bold p-3">Content</div>
-        <div className="col-span-1 font-bold p-3">Hrs</div>
-        <div className="col-span-12 font-bold p-3 pr-0">Remarks</div>
-        {data.logs.map(({ time, content, hours, remarks }, index) => (
-          <Fragment key={index}>
-            <div className="col-span-3 p-3 border-t border-card pl-0">
-              <TableTime time={time} />
-            </div>
-            <div className="col-span-8 p-3 border-t border-card">
-              <TableContent content={content} />
-            </div>
-            <div className="col-span-1 p-3 border-t border-card">{hours}</div>
-            <div className="col-span-12 p-3 border-t border-card pr-0">
-              <TableRemarks remarks={remarks} />
-            </div>
-          </Fragment>
-        ))}
-      </div>
-    </div>
-  </div>
-);
+  );
+};
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   const image = await getOgImage({ title: "Project Log for Vu Van Dung", label: "orbital" });
+  // Fetch once at build time so even if client-side fetch fails we still have most of the log to show
   const data = await getProjectLogJoulev();
   return {
     props: {
@@ -166,15 +160,14 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
       },
       data,
     },
-    revalidate: 24 * 60 * 60,
   };
 };
 
-ProjectLogJoulev.getLayout = (page, { seo, lastUpdated }) => (
+ProjectLogJoulev.getLayout = (page, { seo }) => (
   <BlogLayout
     title="Project Log for Vu Van Dung"
     authors={[authors.joulev]}
-    timestamp={parseISO(lastUpdated)}
+    timestamp={new Date("2022-05-25")}
     seo={seo}
     container
   >


### PR DESCRIPTION
Instead I will use `swr` with client-side fetching for my project log. This will close #74.

And now instead of the project log page only getting updated once a day, it will be updated live, with full fallback data.

Since `getOgImage` will only be run during build time now, it should be fine.