### PR TITLE
Attempt to render customisation frame directly on the DOM

### DIFF
--- a/packages/client/components/home/sections/customisation.tsx
+++ b/packages/client/components/home/sections/customisation.tsx
@@ -1,4 +1,7 @@
-import { FC } from "react";
+import clsx from "clsx";
+import { FC, Fragment } from "react";
+
+import { comments } from "@client/lib/generateCommentHTML";
 
 import A from "@client/components/anchor";
 import Button from "@client/components/buttons";
@@ -7,10 +10,55 @@ import Section from "@client/components/home/section";
 import Window from "@client/components/home/window";
 
 const Illustration: FC<{ codeHtml: string }> = ({ codeHtml }) => {
+  const inputCls =
+    "bg-transparent ring-0 border border-card rounded px-3 py-1 placeholder:text-muted";
   return (
-    <Window tabs={["index.html", "comment.html", "styles.css"]} activeTab={0}>
-      <CodeBlock codeHtml={codeHtml} />
-    </Window>
+    <div className="relative h-[480px]">
+      <div className="absolute top-0 inset-x-0 scale-75 origin-top-left">
+        <Window tabs={["index.html", "comment.html", "styles.css"]} activeTab={0}>
+          <CodeBlock codeHtml={codeHtml} />
+        </Window>
+      </div>
+      <div className="absolute bottom-0 inset-x-0 p-6 rounded border border-card bg-card scale-75 origin-bottom-right pointer-events-none">
+        <hr className="mt-0 mb-4.5" />
+        {comments.map(({ author, text, date }, index) => (
+          <Fragment key={index}>
+            <div className="flex flex-row justify-between mb-4.5">
+              <div className="font-bold">{author}</div>
+              <div className="text-muted">{date}</div>
+            </div>
+            <div>{text}</div>
+            <hr className="my-4.5" />
+          </Fragment>
+        ))}
+        <form onSubmit={() => false}>
+          <div className="grid grid-cols-2 gap-4.5 mb-4.5">
+            <input placeholder="Display name" className={inputCls} />
+            <input placeholder="Email (optional)" className={inputCls} />
+            <textarea placeholder="Content" className={clsx(inputCls, "col-span-full")} />
+          </div>
+          <div className="flex flex-row justify-between">
+            <div className="text-xs text-muted">Styling with Markdown is supported</div>
+            <Button type="submit" className="ml-auto" disabled>
+              Post
+            </Button>
+          </div>
+        </form>
+      </div>
+      <svg width={61} height={106} className="absolute bottom-24 left-[3%] sm:left-[6%]">
+        {["M 1 1 C 1 50 20 90 60 100", "M 40 105 L 60 100 L 47 84"].map((path, i) => (
+          <path
+            d={path}
+            className="stroke-indigo-500"
+            fill="none"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            key={i}
+          />
+        ))}
+      </svg>
+    </div>
   );
 };
 

--- a/packages/client/lib/generateCommentHTML.ts
+++ b/packages/client/lib/generateCommentHTML.ts
@@ -1,4 +1,4 @@
-const comments = [
+export const comments = [
     {
         author: "John Doe",
         text: "This is a great post. I like it.",


### PR DESCRIPTION
If this fix passes

* On all viewport breakpoints
  * [x] `xs`
  * [x] `sm`
  * [x] `md`
  * [x] `lg`
  * [x] `xl`
* On Safari, Chrome and Firefox (the browsers I have right now) without errors (except #58)
  * [x] Safari
  * [x] Chrome
  * [x] Firefox
* On all themes with 100% correct rate
  * System theme (dark)
    * [x] Reload (x5)
    * [x] Change from light theme
    * [x] Change from dark theme
  * Light theme
    * [x] Reload (x5)
    * [x] Change from dark theme
    * [x] Change from system theme
  * Dark theme
    * [x] Reload (x5)
    * [x] Change from light theme
    * [x] Change from system theme

it will be merged.

Fix #38 and close #79.