### PR TITLE
Integrate the auth system on frontend with the backend

### DIFF
--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -2,15 +2,22 @@ const NOT_AUTHENTICATED = new Error(
     "No authenticated users found to link account. Please log in first."
 ) as NodeJS.ErrnoException;
 NOT_AUTHENTICATED.code = "ezkomment/client";
+export { NOT_AUTHENTICATED };
 
 const UNABLE_TO_UPDATE_NAME = new Error(
     "Unable to update display name. Please try again later."
 ) as NodeJS.ErrnoException;
 UNABLE_TO_UPDATE_NAME.code = "ezkomment/client";
+export { UNABLE_TO_UPDATE_NAME };
+
+const UNABLE_TO_UPDATE_PHOTO = new Error(
+    "Unable to update photo. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_UPDATE_PHOTO.code = "ezkomment/client";
+export { UNABLE_TO_UPDATE_PHOTO };
 
 const UNABLE_TO_DELETE_ACCOUNT = new Error(
     "Unable to delete account. Please try again later."
 ) as NodeJS.ErrnoException;
 UNABLE_TO_DELETE_ACCOUNT.code = "ezkomment/client";
-
-export { NOT_AUTHENTICATED, UNABLE_TO_UPDATE_NAME, UNABLE_TO_DELETE_ACCOUNT };
+export { UNABLE_TO_DELETE_ACCOUNT };

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -8,4 +8,9 @@ const UNABLE_TO_UPDATE_NAME = new Error(
 ) as NodeJS.ErrnoException;
 UNABLE_TO_UPDATE_NAME.code = "ezkomment/client";
 
-export { NOT_AUTHENTICATED, UNABLE_TO_UPDATE_NAME };
+const UNABLE_TO_DELETE_ACCOUNT = new Error(
+    "Unable to delete account. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_DELETE_ACCOUNT.code = "ezkomment/client";
+
+export { NOT_AUTHENTICATED, UNABLE_TO_UPDATE_NAME, UNABLE_TO_DELETE_ACCOUNT };

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -2,4 +2,10 @@ const NOT_AUTHENTICATED = new Error(
     "No authenticated users found to link account. Please log in first."
 ) as NodeJS.ErrnoException;
 NOT_AUTHENTICATED.code = "ezkomment/client";
-export { NOT_AUTHENTICATED };
+
+const UNABLE_TO_UPDATE_NAME = new Error(
+    "Unable to update display name. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_UPDATE_NAME.code = "ezkomment/client";
+
+export { NOT_AUTHENTICATED, UNABLE_TO_UPDATE_NAME };

--- a/client/lib/firebase/auth.ts
+++ b/client/lib/firebase/auth.ts
@@ -75,7 +75,7 @@ export async function reauthenticate({ setLoading }: AppAuth, provider: Provider
 export async function updateDisplayName({ setLoading }: AppAuth, displayName: string) {
     setLoading(true);
     if (!auth.currentUser) throw E.NOT_AUTHENTICATED;
-    const { success } = await fetcher("POST", `/api/users/${auth.currentUser.uid}`, {
+    const { success } = await fetcher("PUT", `/api/users/${auth.currentUser.uid}`, {
         body: JSON.stringify({ displayName }),
     });
     await auth.currentUser.reload();

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -22,6 +22,7 @@ import {
   reauthenticate,
   unlink,
   updateDisplayName,
+  updatePhoto,
 } from "~/client/lib/firebase/auth";
 
 import AuthError from "~/client/components/auth/error";
@@ -61,11 +62,24 @@ const ProfileSection: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [image]);
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = async event => {
+  const handleDisplayNameSubmit: FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault();
     try {
       await updateDisplayName(auth, displayName);
       setMsg({ type: "success", message: "Display name updated successfully." });
+    } catch (err: any) {
+      setMsg({ type: "error", message: <AuthError err={err} /> });
+      auth.setLoading(false);
+    }
+  };
+
+  const handlePhotoSubmit: FormEventHandler<HTMLFormElement> = async event => {
+    event.preventDefault();
+    if (!image) return;
+    try {
+      await updatePhoto(auth, image);
+      setMsg({ type: "success", message: "Photo updated successfully." });
+      setImage(null);
     } catch (err: any) {
       setMsg({ type: "error", message: <AuthError err={err} /> });
       auth.setLoading(false);
@@ -86,7 +100,7 @@ const ProfileSection: FC = () => {
         </Banner>
       )}
       {msg && <MsgBanner msg={msg} />}
-      <form className="flex flex-col gap-6 mb-12" onSubmit={handleSubmit}>
+      <form className="flex flex-col gap-6 mb-12" onSubmit={handleDisplayNameSubmit}>
         <InputDetachedLabel
           label="Display name"
           placeholder="Your name"
@@ -106,7 +120,7 @@ const ProfileSection: FC = () => {
           </Button>
         </RightAligned>
       </form>
-      <form className="flex flex-col gap-6">
+      <form className="flex flex-col gap-6" onSubmit={handlePhotoSubmit}>
         <div className="flex flex-row items-start gap-6">
           <div className="flex-grow">
             <div className="font-semibold mb-3">Profile image</div>


### PR DESCRIPTION
* [x] Update user display name (`PUT` `/users/:uid`)
* [x] Update user photo (awaiting #98)
* [x] Delete user (`DELETE` `/users/:uid`)
* [x] Handle errors (awaiting #101)

All other actions require authentication by popups so are really hard to do with the backend, so we will use client-based Firebase for that.

Until this PR is merged, the deployment can be viewed at https://test.joulev.dev.