### PR TITLE
Integrate CRUD actions for sites to frontend

### DIFF
--- a/client/components/app/handleSite.tsx
+++ b/client/components/app/handleSite.tsx
@@ -23,16 +23,11 @@ const sitePages = ({ title, activeTab, removePadding, Loading, Content }: SitePa
   const Page: NextPageWithLayout = () => {
     const { user } = useAuth();
     const router = useRouter();
-    useEffect(() => {
-      if (!router.query.switchingSiteName) return;
-      router.push(router.asPath.split("?")[0], undefined, { shallow: true });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [user]);
 
     if (!user || !router.isReady) return <Loading />;
     const site = user.sites.find(s => s.name === router.query.siteName);
     if (!site) {
-      if (!router.query.switchingSiteName || router.query.switchingSiteName !== "1") {
+      if (!router.query.loading || router.query.loading !== "1") {
         router.push("/404", router.asPath);
         return null;
       } else return <Loading />;

--- a/client/components/app/handleSite.tsx
+++ b/client/components/app/handleSite.tsx
@@ -11,7 +11,7 @@ import { NextPageWithLayout } from "~/types/client/utils.type";
 type Props = { siteName: string };
 type Param = Props;
 
-const sitePages = ({ title, activeTab, Loading, Content }: SitePagesOptions) => {
+const sitePages = ({ title, activeTab, removePadding, Loading, Content }: SitePagesOptions) => {
   const Page: NextPageWithLayout<Props> = ({ siteName }) => {
     const { user } = useAuth();
     const router = useRouter();
@@ -32,6 +32,7 @@ const sitePages = ({ title, activeTab, Loading, Content }: SitePagesOptions) => 
       activeTab={activeTab}
       siteName={siteName}
       loadingScreen={<Loading />}
+      removePadding={removePadding}
     >
       {page}
     </AppLayout>

--- a/client/components/app/handleSite.tsx
+++ b/client/components/app/handleSite.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { FC } from "react";
+import { FC, useEffect } from "react";
 
 import SiteContext from "~/client/context/site";
 import useAuth from "~/client/hooks/auth";
@@ -23,13 +23,19 @@ const sitePages = ({ title, activeTab, removePadding, Loading, Content }: SitePa
   const Page: NextPageWithLayout = () => {
     const { user } = useAuth();
     const router = useRouter();
+    useEffect(() => {
+      if (!router.query.switchingSiteName) return;
+      router.push(router.asPath.split("?")[0], undefined, { shallow: true });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [user]);
+
     if (!user || !router.isReady) return <Loading />;
     const site = user.sites.find(s => s.name === router.query.siteName);
     if (!site) {
-      // I'm not even sure if this is the recommended way to do a "client-side" 404, but it works and
-      // it is *not* a workaround (I think).
-      router.push("/404", router.asPath);
-      return null;
+      if (!router.query.switchingSiteName || router.query.switchingSiteName !== "1") {
+        router.push("/404", router.asPath);
+        return null;
+      } else return <Loading />;
     }
     return <SiteContextProvider siteId={site.id} Content={Content} />;
   };

--- a/client/components/app/handleSite.tsx
+++ b/client/components/app/handleSite.tsx
@@ -1,0 +1,45 @@
+import { GetStaticPaths, GetStaticProps } from "next";
+import { useRouter } from "next/router";
+
+import useAuth from "~/client/hooks/auth";
+
+import AppLayout from "~/client/layouts/app";
+
+import { SitePagesOptions } from "~/types/client/page.type";
+import { NextPageWithLayout } from "~/types/client/utils.type";
+
+type Props = { siteName: string };
+type Param = Props;
+
+const sitePages = ({ title, activeTab, Loading, Content }: SitePagesOptions) => {
+  const Page: NextPageWithLayout<Props> = ({ siteName }) => {
+    const { user } = useAuth();
+    const router = useRouter();
+    if (!user) return <Loading />;
+    const site = user.sites.find(s => s.name === siteName);
+    if (!site) {
+      // I'm not even sure if this is the recommended way to do a "client-side" 404, but it works and
+      // it is *not* a workaround (I think).
+      router.push("/404", router.asPath);
+      return null;
+    }
+    return <Content siteId={site.id} />;
+  };
+  Page.getLayout = (page, { siteName }) => (
+    <AppLayout
+      title={siteName ? title(siteName) : "Loading"}
+      type="site"
+      activeTab={activeTab}
+      siteName={siteName}
+      loadingScreen={<Loading />}
+    >
+      {page}
+    </AppLayout>
+  );
+  const getStaticPaths: GetStaticPaths<Param> = () => ({ paths: [], fallback: true });
+  const getStaticProps: GetStaticProps<Props, Param> = ({ params }) =>
+    params && params.siteName ? { props: { siteName: params.siteName } } : { notFound: true };
+  return { Page, getStaticPaths, getStaticProps };
+};
+
+export default sitePages;

--- a/client/components/app/handleSite.tsx
+++ b/client/components/app/handleSite.tsx
@@ -1,7 +1,10 @@
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
+import { FC } from "react";
 
+import SiteContext from "~/client/context/site";
 import useAuth from "~/client/hooks/auth";
+import { useSiteInit } from "~/client/hooks/site";
 
 import AppLayout from "~/client/layouts/app";
 
@@ -10,6 +13,15 @@ import { NextPageWithLayout } from "~/types/client/utils.type";
 
 type Props = { siteName: string };
 type Param = Props;
+
+const SiteContextProvider: FC<{ siteId: string; Content: FC }> = ({ siteId, Content }) => {
+  const { site, mutate } = useSiteInit(siteId);
+  return (
+    <SiteContext.Provider value={{ site, mutate }}>
+      <Content />
+    </SiteContext.Provider>
+  );
+};
 
 const sitePages = ({ title, activeTab, removePadding, Loading, Content }: SitePagesOptions) => {
   const Page: NextPageWithLayout<Props> = ({ siteName }) => {
@@ -23,7 +35,7 @@ const sitePages = ({ title, activeTab, removePadding, Loading, Content }: SitePa
       router.push("/404", router.asPath);
       return null;
     }
-    return <Content siteId={site.id} />;
+    return <SiteContextProvider siteId={site.id} Content={Content} />;
   };
   Page.getLayout = (page, { siteName }) => (
     <AppLayout

--- a/client/components/app/navbar/main.tsx
+++ b/client/components/app/navbar/main.tsx
@@ -22,6 +22,7 @@ function items(pageType: PageType, siteName?: string, pageId?: string): Items<ty
         account: { href: `/app/account`, label: ["Account", "Account settings"] },
       };
     case "site":
+      if (!siteName) return {};
       return {
         all: { href: `/app/site/${siteName}`, label: "All pages" },
         customise: {
@@ -31,6 +32,7 @@ function items(pageType: PageType, siteName?: string, pageId?: string): Items<ty
         settings: { href: `/app/site/${siteName}/settings`, label: "Settings" },
       };
     case "page":
+      if (!siteName || !pageId) return {};
       return {
         all: { href: `/app/site/${siteName}/${pageId}`, label: "All comments" },
         settings: { href: `/app/site/${siteName}/${pageId}/settings`, label: "Settings" },
@@ -113,6 +115,7 @@ const MainNav: FC<CurrentPage> = ({ type, activeTab, siteName, pageId }) => {
               )}
             </MainNavButton>
           ))}
+          <div className="h-[42px]" />
         </nav>
       </div>
     </div>

--- a/client/components/blankIllustration.tsx
+++ b/client/components/blankIllustration.tsx
@@ -1,0 +1,40 @@
+import { FC } from "react";
+
+const BlankIllustration: FC = () => (
+  <svg className="text-neutral-300 dark:text-neutral-700 w-full" viewBox="0 0 286 256">
+    <path
+      d="M195.5 0.5C247.25 0.5 285.5 35.6553 285.5 75.3467C285.5 112.97 253.154 135.309 236.369 142.364C235.035 142.925 234.492 144.56 235.271 145.789L255.051 176.998C256.294 178.959 254.15 181.31 252.107 180.226L195.992 150.454C195.669 150.283 195.305 150.194 194.94 150.192C143.474 149.94 105.5 114.895 105.5 75.3467C105.5 35.6553 143.75 0.5 195.5 0.5Z"
+      className="stroke-card fill-card stroke-1"
+    />
+    <rect
+      width="90"
+      height="12"
+      rx="4"
+      transform="matrix(-1 0 0 1 240.5 48.5)"
+      className="fill-current"
+    />
+    <rect
+      width="90"
+      height="12"
+      rx="4"
+      transform="matrix(-1 0 0 1 240.5 69.5)"
+      className="fill-current"
+    />
+    <rect
+      width="90"
+      height="12"
+      rx="4"
+      transform="matrix(-1 0 0 1 240.5 90.5)"
+      className="fill-current"
+    />
+    <path
+      d="M90.5 75.5C38.75 75.5 0.5 110.655 0.5 150.347C0.5 187.97 32.8458 210.309 49.6308 217.364C50.9653 217.925 51.5077 219.56 50.7292 220.789L30.949 251.998C29.7059 253.959 31.8497 256.31 33.8929 255.226L90.0079 225.454C90.3313 225.283 90.6949 225.194 91.06 225.192C142.526 224.94 180.5 189.895 180.5 150.347C180.5 110.655 142.25 75.5 90.5 75.5Z"
+      className="stroke-card fill-card stroke-1"
+    />
+    <rect x="45.5" y="123.5" width="90" height="12" rx="4" className="fill-current" />
+    <rect x="45.5" y="144.5" width="90" height="12" rx="4" className="fill-current" />
+    <rect x="45.5" y="165.5" width="90" height="12" rx="4" className="fill-current" />
+  </svg>
+);
+
+export default BlankIllustration;

--- a/client/components/copiableCode.tsx
+++ b/client/components/copiableCode.tsx
@@ -14,10 +14,6 @@ import IconLabel from "./utils/iconAndLabel";
  * @note Here we don't use `children`, because to copy something to clipboard, we must use a string.
  * Hence `content` is strongly typed as `string`.
  *
- * @note Currently the scrolling effect is not working on mobile (at least Safari), so do take
- * care when using this component with a long `content` string. TODO: Implement a workaround.
- * C'mon Safari you're really becoming the second Internet Explorer?
- *
  * @note https://stackoverflow.com/q/24193272
  *
  * @param props.content The content to be copied to the clipboard

--- a/client/components/forms/iconUpload.tsx
+++ b/client/components/forms/iconUpload.tsx
@@ -1,0 +1,71 @@
+import clsx from "clsx";
+import { FC } from "react";
+import { useEffect, useState } from "react";
+
+import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
+
+import { IconUploaderProps } from "~/types/client/components.type";
+
+const IconUpload: FC<IconUploaderProps> = ({ label, helpText, onUpdate }) => {
+  const [image, setImage] = useState<File | null>(null);
+  const [imageSrc, setImageSrc] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!image) {
+      setImageSrc(undefined);
+      return;
+    }
+    setImageSrc(URL.createObjectURL(image));
+    if (onUpdate) onUpdate(image);
+    return () => URL.revokeObjectURL(imageSrc!);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [image]);
+
+  return (
+    <div className="flex flex-row items-start gap-6">
+      <div className="flex-grow">
+        <div className="font-semibold mb-3">{label}</div>
+        <div>{helpText}</div>
+      </div>
+      <div className="min-w-min">
+        <label className="cursor-pointer block w-18 md:w-24 overflow-hidden">
+          {imageSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={imageSrc ?? "/images/default-photo.svg"}
+              alt="Photo"
+              className="w-18 h-18 md:w-24 md:h-24 rounded-full"
+            />
+          ) : (
+            <div
+              className={clsx(
+                "w-18 h-18 md:w-24 md:h-24 rounded-full flex flex-col justify-center items-center transition",
+                "border border-dashed border-card text-neutral-300 dark:text-neutral-700 hover:text-muted"
+              )}
+            >
+              <AddOutlinedIcon fontSize="large" />
+              <div className="hidden md:block text-xs">upload</div>
+            </div>
+          )}
+          <input
+            type="file"
+            onChange={event => {
+              if (
+                !event.target.files ||
+                event.target.files.length === 0 ||
+                !(event.target.files[0] instanceof File) ||
+                !/\.(jpe?g|png)$/i.test(event.target.files[0].name)
+              )
+                setImage(null);
+              else setImage(event.target.files[0]);
+            }}
+            className="hidden"
+            accept=".jpg, .jpeg, .png"
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default IconUpload;

--- a/client/components/forms/iconUpload.tsx
+++ b/client/components/forms/iconUpload.tsx
@@ -6,21 +6,17 @@ import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 
 import { IconUploaderProps } from "~/types/client/components.type";
 
-const IconUpload: FC<IconUploaderProps> = ({ label, helpText, onUpdate }) => {
-  const [image, setImage] = useState<File | null>(null);
+const IconUpload: FC<IconUploaderProps> = ({ label, helpText, file, onUpdate }) => {
   const [imageSrc, setImageSrc] = useState<string | undefined>(undefined);
-
   useEffect(() => {
-    if (!image) {
+    if (!file) {
       setImageSrc(undefined);
       return;
     }
-    setImageSrc(URL.createObjectURL(image));
-    if (onUpdate) onUpdate(image);
+    setImageSrc(URL.createObjectURL(file));
     return () => URL.revokeObjectURL(imageSrc!);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [image]);
-
+  }, [file]);
   return (
     <div className="flex flex-row items-start gap-6">
       <div className="flex-grow">
@@ -50,14 +46,15 @@ const IconUpload: FC<IconUploaderProps> = ({ label, helpText, onUpdate }) => {
           <input
             type="file"
             onChange={event => {
+              if (!onUpdate) return;
               if (
                 !event.target.files ||
                 event.target.files.length === 0 ||
                 !(event.target.files[0] instanceof File) ||
                 !/\.(jpe?g|png)$/i.test(event.target.files[0].name)
               )
-                setImage(null);
-              else setImage(event.target.files[0]);
+                onUpdate(null);
+              else onUpdate(event.target.files[0]);
             }}
             className="hidden"
             accept=".jpg, .jpeg, .png"

--- a/client/components/forms/input.tsx
+++ b/client/components/forms/input.tsx
@@ -23,11 +23,12 @@ import { InputDetachedLabelProps, InputProps } from "~/types/client/components.t
  *
  * @note As a result, if you provide `onChange` directly, `onUpdate` will have no effect.
  */
-const Input: FC<InputProps> = ({ label, icon, onUpdate, type, className, ...rest }) => (
+const Input: FC<InputProps> = ({ label, icon, isInvalid, onUpdate, type, className, ...rest }) => (
   <label
     className={clsx(
       "group flex flex-row rounded border divide-x transition bg-card border-card divide-card",
       "focus-within:border-muted focus-within:divide-muted hover:border-muted hover:divide-muted",
+      isInvalid && "!border-red-500 !divide-red-500",
       className
     )}
   >

--- a/client/components/messageBanner.tsx
+++ b/client/components/messageBanner.tsx
@@ -1,13 +1,31 @@
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
+
+import CloseOutlinedIcon from "@mui/icons-material/CloseOutlined";
 
 import Banner from "~/client/components/banner";
 
 import { ResponseMessage as Msg } from "~/types/client/utils.type";
 
-const MsgBanner: FC<{ msg: NonNullable<Msg> }> = ({ msg }) => (
-  <Banner variant={msg.type === "success" ? "info" : "error"} className="mb-6">
-    {msg.message}
-  </Banner>
-);
+const MsgBanner: FC<{ msg: NonNullable<Msg> }> = ({ msg }) => {
+  const [show, setShow] = useState(true);
+  useEffect(() => setShow(true), [msg]);
+  if (!show) return null;
+  return (
+    <Banner
+      variant={msg.type === "success" ? "info" : "error"}
+      className="mb-6 flex flex-row items-start gap-3 pr-3"
+    >
+      <div className="flex-1">{msg.message}</div>
+      <div>
+        <button
+          className="text-muted hover:text-neutral-900 dark:hover:text-neutral-100 transition"
+          onClick={() => setShow(false)}
+        >
+          <CloseOutlinedIcon />
+        </button>
+      </div>
+    </Banner>
+  );
+};
 
 export default MsgBanner;

--- a/client/components/messageBanner.tsx
+++ b/client/components/messageBanner.tsx
@@ -1,0 +1,13 @@
+import { FC } from "react";
+
+import Banner from "~/client/components/banner";
+
+import { ResponseMessage as Msg } from "~/types/client/utils.type";
+
+const MsgBanner: FC<{ msg: NonNullable<Msg> }> = ({ msg }) => (
+  <Banner variant={msg.type === "success" ? "info" : "error"} className="mb-6">
+    {msg.message}
+  </Banner>
+);
+
+export default MsgBanner;

--- a/client/context/site.ts
+++ b/client/context/site.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+import { SiteContextProps } from "~/types/client/page.type";
+
+const SiteContext = createContext<SiteContextProps>({
+    site: undefined,
+    mutate: async () => undefined,
+});
+
+export default SiteContext;

--- a/client/hooks/auth.ts
+++ b/client/hooks/auth.ts
@@ -4,7 +4,7 @@ import { useContext, useEffect, useState } from "react";
 
 import AuthContext from "~/client/context/auth";
 import firebaseApp from "~/client/lib/firebase/app";
-import { getUser } from "~/client/lib/firebase/auth";
+import { refreshUser } from "~/client/lib/firebase/auth";
 
 import { AppAuth, User } from "~/types/client/auth.type";
 
@@ -19,8 +19,7 @@ export function useAuthInit(): AppAuth {
     useEffect(() => {
         const unsubscribe = onAuthStateChanged(auth, async firebaseUser => {
             if (firebaseUser) {
-                const user = await getUser();
-                setUser(user);
+                await refreshUser({ user, setUser, loading, setLoading });
                 if (router.pathname.startsWith("/auth")) router.push("/app/dashboard");
             } else {
                 setUser(null);

--- a/client/hooks/auth.ts
+++ b/client/hooks/auth.ts
@@ -4,10 +4,10 @@ import { useContext, useEffect, useState } from "react";
 
 import AuthContext from "~/client/context/auth";
 import firebaseApp from "~/client/lib/firebase/app";
+import { getUser } from "~/client/lib/firebase/auth";
 
 import { AppAuth, User } from "~/types/client/auth.type";
 
-import { getUser } from "../lib/firebase/auth";
 import { endProgress, startProgress } from "./nprogress";
 
 export function useAuthInit(): AppAuth {

--- a/client/hooks/auth.ts
+++ b/client/hooks/auth.ts
@@ -1,11 +1,15 @@
-import { User, getAuth, onAuthStateChanged } from "firebase/auth";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 
 import AuthContext from "~/client/context/auth";
+import { UNKNOWN_ERROR } from "~/client/lib/errors";
+import { internalFetcher as fetcher } from "~/client/lib/fetcher";
 import firebaseApp from "~/client/lib/firebase/app";
 
-import { AppAuth } from "~/types/client/auth.type";
+import { AppAuth, User } from "~/types/client/auth.type";
+import { Site } from "~/types/server";
+import { ApiResponseBody } from "~/types/server/nextApi.type";
 
 import { endProgress, startProgress } from "./nprogress";
 
@@ -16,16 +20,26 @@ export function useAuthInit(): AppAuth {
     const auth = getAuth(firebaseApp);
 
     useEffect(() => {
-        const unsubscribe = onAuthStateChanged(auth, user => {
-            setUser(user);
-            if (process.env.NODE_ENV === "development") console.log(user);
-            if (!user && router.pathname.startsWith("/app")) router.push("/auth");
-            else if (user && router.pathname.startsWith("/auth")) router.push("/app/dashboard");
+        const unsubscribe = onAuthStateChanged(auth, async user => {
+            if (user) {
+                const { success, body } = await fetcher({ url: `/api/users/${user.uid}/sites` });
+                if (!success) throw UNKNOWN_ERROR;
+                const sites = (body as ApiResponseBody).data as Site[];
+                setUser({ ...user, sites });
+                if (router.pathname.startsWith("/auth")) router.push("/app/dashboard");
+            } else {
+                setUser(null);
+                if (router.pathname.startsWith("/app")) router.push("/auth");
+            }
             setLoading(false);
         });
         return () => unsubscribe();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        if (process.env.NODE_ENV === "development") console.log(user);
+    }, [user]);
 
     useEffect(() => {
         if (loading) startProgress();

--- a/client/hooks/site.ts
+++ b/client/hooks/site.ts
@@ -1,0 +1,19 @@
+import { useContext } from "react";
+import useSWR from "swr";
+
+import SiteContext from "~/client/context/site";
+import { internalSWRGenerator } from "~/client/lib/fetcher";
+
+import { Site } from "~/types/server";
+
+export function useSiteInit(siteId: string) {
+    const { data: site, mutate } = useSWR(
+        `/api/sites/${siteId}`,
+        internalSWRGenerator<Site | undefined>()
+    );
+    return { site, mutate };
+}
+
+export function useSite() {
+    return useContext(SiteContext);
+}

--- a/client/layouts/app.tsx
+++ b/client/layouts/app.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import Head from "next/head";
-import { FC } from "react";
+import { useRouter } from "next/router";
+import { FC, useEffect } from "react";
 
 import useAuth from "~/client/hooks/auth";
 
@@ -12,6 +13,12 @@ import { AppProps } from "~/types/client/components.type";
 
 const App: FC<AppProps> = ({ title, removePadding, loadingScreen, children, ...rest }) => {
   const { user } = useAuth();
+  const router = useRouter();
+  useEffect(() => {
+    if (!router.query.loading) return;
+    router.push(router.asPath.split("?")[0], undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
   return (
     <>
       <Head>
@@ -20,7 +27,7 @@ const App: FC<AppProps> = ({ title, removePadding, loadingScreen, children, ...r
       </Head>
       <Navbar {...rest} />
       <main className={clsx("container", removePadding || "py-9")}>
-        {user
+        {user && !router.query.loading
           ? children
           : loadingScreen ?? <>You are accessing a protected page. Authenticating&hellip;</>}
       </main>

--- a/client/layouts/errors.tsx
+++ b/client/layouts/errors.tsx
@@ -17,7 +17,7 @@ export const ErrorLayout: FC<{ code?: number }> = ({ code }) => {
   return (
     <>
       <Head>
-        <title>Error{code ? ` ${code}` : ""} | ezkomment</title>
+        <title>{`Error${code ? ` ${code}` : ""} | ezkomment`}</title>
         <meta name="robots" content="noindex" />
       </Head>
       <main className="h-screen grid place-items-center">

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -21,3 +21,9 @@ const UNABLE_TO_DELETE_ACCOUNT = new Error(
 ) as NodeJS.ErrnoException;
 UNABLE_TO_DELETE_ACCOUNT.code = "ezkomment/client";
 export { UNABLE_TO_DELETE_ACCOUNT };
+
+const UNABLE_TO_CREATE_SITE = new Error(
+    "Unable to create site. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_CREATE_SITE.code = "ezkomment/client";
+export { UNABLE_TO_CREATE_SITE };

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -39,6 +39,12 @@ const UNABLE_TO_UPDATE_SITE = new Error(
 UNABLE_TO_UPDATE_SITE.code = "ezkomment/client";
 export { UNABLE_TO_UPDATE_SITE };
 
+const UNABLE_TO_DELETE_SITE = new Error(
+    "Unable to delete site. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_DELETE_SITE.code = "ezkomment/client";
+export { UNABLE_TO_DELETE_SITE };
+
 const SITE_ALREADY_EXISTS = new Error(
     "Site already exists. Please try again with a different name."
 ) as NodeJS.ErrnoException;

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -33,6 +33,12 @@ const UNABLE_TO_CREATE_SITE = new Error(
 UNABLE_TO_CREATE_SITE.code = "ezkomment/client";
 export { UNABLE_TO_CREATE_SITE };
 
+const UNABLE_TO_UPDATE_SITE = new Error(
+    "Unable to update site. Please try again later."
+) as NodeJS.ErrnoException;
+UNABLE_TO_UPDATE_SITE.code = "ezkomment/client";
+export { UNABLE_TO_UPDATE_SITE };
+
 const SITE_ALREADY_EXISTS = new Error(
     "Site already exists. Please try again with a different name."
 ) as NodeJS.ErrnoException;

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -27,3 +27,9 @@ const UNABLE_TO_CREATE_SITE = new Error(
 ) as NodeJS.ErrnoException;
 UNABLE_TO_CREATE_SITE.code = "ezkomment/client";
 export { UNABLE_TO_CREATE_SITE };
+
+const SITE_ALREADY_EXISTS = new Error(
+    "Site already exists. Please try again with a different name."
+) as NodeJS.ErrnoException;
+SITE_ALREADY_EXISTS.code = "ezkomment/client";
+export { SITE_ALREADY_EXISTS };

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -1,3 +1,8 @@
+const UNKNOWN_ERROR = new Error(
+    "Unknown error. Please contact the administrator."
+) as NodeJS.ErrnoException;
+export { UNKNOWN_ERROR };
+
 const NOT_AUTHENTICATED = new Error(
     "No authenticated users found to link account. Please log in first."
 ) as NodeJS.ErrnoException;

--- a/client/lib/fetcher.ts
+++ b/client/lib/fetcher.ts
@@ -21,7 +21,11 @@ export async function internalFetcher({ url, method, options }: FetchOptions, is
             Authorization: `Bearer ${token}`,
         },
     });
-    return { success: response.ok, body: (await response.json()) as ApiResponseBody | ApiError };
+    return {
+        success: response.ok,
+        status: response.status,
+        body: (await response.json()) as ApiResponseBody | ApiError,
+    };
 }
 
 /**

--- a/client/lib/fetcher.ts
+++ b/client/lib/fetcher.ts
@@ -1,0 +1,57 @@
+import { getAuth } from "firebase/auth";
+
+import { FetchOptions } from "~/types/client/utils.type";
+import { ApiError, ApiResponseBody } from "~/types/server/nextApi.type";
+
+import { NOT_AUTHENTICATED } from "./errors";
+
+/**
+ * Fetch data from the backend in an authenticated context.
+ */
+export async function internalFetcher({ url, method, options }: FetchOptions, isJson = true) {
+    const user = getAuth().currentUser;
+    if (!user) throw NOT_AUTHENTICATED;
+    const token = await user.getIdToken();
+    const response = await fetch(url, {
+        ...options,
+        method,
+        headers: {
+            ...(options?.headers ?? {}),
+            ...(isJson ? { "Content-Type": "application/json" } : {}),
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return { success: response.ok, body: (await response.json()) as ApiResponseBody | ApiError };
+}
+
+/**
+ * A generator for `useSWR` fetchers.
+ *
+ * Generally using the async function directly is enough, but I cannot get SWR to get the type
+ * correctly. The async has to have a generic type, but SWR doesn't allow passing that type argument
+ * to `fetcher` param (obviously), so while I wanted to do something like this, it's not possible:
+ *
+ * ```ts
+ * async function fetcher<T>({ url, options }: Omit<FetchOptions, "method">) {
+ *   const { body } = internalFetcher({ url, method: "GET", options });
+ *   return body.data as T
+ * }
+ * // ...
+ * const { data } = useSWR({ url }, fetcher<Site>);
+ * ```
+ *
+ * So I had to make this generator purely for typings, so that I can use, say,
+ *
+ * ```ts
+ * const { data } = useSWR({ url }, internalSWRGenerator<Site>());
+ * ```
+ *
+ * @returns A fetcher for `useSWR`
+ */
+export function internalSWRGenerator<T = any>() {
+    return async ({ url, options }: Omit<FetchOptions, "method">) => {
+        const { success, body } = await internalFetcher({ url, method: "GET", options });
+        if (!success) throw new Error(`Unknown error: ${(body as ApiError).error}`);
+        return (body as ApiResponseBody).data as T;
+    };
+}

--- a/client/lib/firebase/auth.ts
+++ b/client/lib/firebase/auth.ts
@@ -67,11 +67,9 @@ export async function getUser() {
     return { ...user, sites };
 }
 
-export async function refreshUser({ setUser, setLoading }: AppAuth) {
-    setLoading(true);
+export async function refreshUser({ setUser }: AppAuth) {
     const user = await getUser();
     setUser(user);
-    setLoading(false);
 }
 
 export async function updateDisplayName(appAuth: AppAuth, displayName: string) {

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -74,7 +74,7 @@
         @apply divide-neutral-500;
     }
     .pulse {
-        @apply bg-neutral-300 dark:bg-neutral-700 animate-pulse;
+        @apply bg-neutral-300 dark:bg-neutral-700 rounded animate-pulse;
     }
     .logo-width {
         @apply w-[calc(397px/80*36)];

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -61,8 +61,14 @@
     .bg-card {
         @apply bg-white dark:bg-black;
     }
+    .fill-card {
+        @apply fill-white dark:fill-black;
+    }
     .border-card {
         @apply border-neutral-300 dark:border-neutral-700;
+    }
+    .stroke-card {
+        @apply stroke-neutral-300 dark:stroke-neutral-700;
     }
     .border-muted {
         @apply border-neutral-500; /* intended for hover, focus states of border */

--- a/misc/validate.ts
+++ b/misc/validate.ts
@@ -1,0 +1,15 @@
+/**
+ * @file validate.ts
+ *
+ * Since we do a lot of validating on both frontend and backend, it is wise to use the same
+ * validation logic on both ends. So that we can make change easily whenever we need to.
+ */
+// Import this way for the sake of tree-shaking
+import isSlug from "validator/lib/isSlug";
+import isURL from "validator/lib/isURL";
+
+export const SITE = {
+    nameIsValid: (name: string) => isSlug(name),
+    domainIsValid: (domain: string) =>
+        isURL(domain, { require_protocol: true, protocols: ["http", "https"] }),
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -18,7 +18,7 @@ import { AppPropsWithLayout } from "~/types/client/utils.type";
 import "~/client/styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  useNProgress();
+  // useNProgress(); // The routes are fast enough that this isn't necessary
   const { mode, setMode } = useModeInit();
   const breakpoint = useBreakpointInit();
   const router = useRouter();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,7 +21,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   useNProgress();
   const { mode, setMode } = useModeInit();
   const breakpoint = useBreakpointInit();
-  const { asPath } = useRouter();
+  const router = useRouter();
   const getLayout = Component.getLayout ?? (page => page);
   return (
     <ErrorBoundary>
@@ -42,10 +42,10 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
               id="wrapper"
               className={clsx(
                 "relative min-h-[100vh]",
-                asPath.startsWith("/docs") || "pb-[250px] sm:pb-[165px]"
+                router.asPath.startsWith("/docs") || "pb-[250px] sm:pb-[165px]"
               )}
             >
-              {getLayout(<Component {...pageProps} />, pageProps)}
+              {getLayout(<Component {...pageProps} />, pageProps, router)}
             </div>
           </MDXProvider>
         </BreakpointContext.Provider>

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -362,18 +362,18 @@ const Account: NextPageWithLayout = () => {
 
 const LoadingSection: FC = () => (
   <section>
-    <div className="h-8 w-36 rounded pulse mb-6" />
-    <div className="h-4 rounded pulse mb-3" />
-    <div className="h-4 rounded pulse mb-3" />
-    <div className="h-4 rounded pulse mb-6" />
-    <div className="h-6 w-48 rounded pulse mb-3" />
-    <div className="h-9 rounded pulse mb-3" />
-    <div className="h-4 rounded pulse mb-6" />
-    <div className="h-6 w-48 rounded pulse mb-3" />
-    <div className="h-9 rounded pulse mb-3" />
-    <div className="h-4 rounded pulse mb-6" />
+    <div className="h-8 w-36 pulse mb-6" />
+    <div className="h-4 pulse mb-3" />
+    <div className="h-4 pulse mb-3" />
+    <div className="h-4 pulse mb-6" />
+    <div className="h-6 w-48 pulse mb-3" />
+    <div className="h-9 pulse mb-3" />
+    <div className="h-4 pulse mb-6" />
+    <div className="h-6 w-48 pulse mb-3" />
+    <div className="h-9 pulse mb-3" />
+    <div className="h-4 pulse mb-6" />
     <RightAligned>
-      <div className="h-9 w-32 rounded pulse" />
+      <div className="h-9 w-32 pulse" />
     </RightAligned>
   </section>
 );

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
-import { User } from "firebase/auth";
-import { FC, FormEventHandler, MouseEvent, ReactNode, useEffect, useState } from "react";
+import { FC, FormEventHandler, MouseEvent, useEffect, useState } from "react";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
@@ -35,7 +34,7 @@ import Modal from "~/client/components/modal";
 import RightAligned from "~/client/components/utils/rightAligned";
 import AppLayout from "~/client/layouts/app";
 
-import { Provider } from "~/types/client/auth.type";
+import { Provider, User } from "~/types/client/auth.type";
 import { ResponseMessage as Msg, NextPageWithLayout } from "~/types/client/utils.type";
 
 const ProfileSection: FC = () => {

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -104,6 +104,7 @@ const ProfileSection: FC = () => {
         <IconUpload
           label="Profile photo"
           helpText="Your profile picture is displayed on your replies to comments. It is also used as your general profile picture in this site."
+          file={image}
           onUpdate={setImage}
         />
         <RightAligned>

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -30,20 +30,13 @@ import Banner from "~/client/components/banner";
 import Button from "~/client/components/buttons";
 import CopiableCode from "~/client/components/copiableCode";
 import { InputDetachedLabel } from "~/client/components/forms/input";
+import MsgBanner from "~/client/components/messageBanner";
 import Modal from "~/client/components/modal";
 import RightAligned from "~/client/components/utils/rightAligned";
 import AppLayout from "~/client/layouts/app";
 
 import { Provider } from "~/types/client/auth.type";
-import { NextPageWithLayout } from "~/types/client/utils.type";
-
-type Msg = { type: "success" | "error"; message: ReactNode } | null;
-
-const MsgBanner: FC<{ msg: NonNullable<Msg> }> = ({ msg }) => (
-  <Banner variant={msg.type === "success" ? "info" : "error"} className="mb-6">
-    {msg.message}
-  </Banner>
-);
+import { ResponseMessage as Msg, NextPageWithLayout } from "~/types/client/utils.type";
 
 const ProfileSection: FC = () => {
   const auth = useAuth();

--- a/pages/app/account.tsx
+++ b/pages/app/account.tsx
@@ -1,7 +1,5 @@
-import clsx from "clsx";
-import { FC, FormEventHandler, MouseEvent, useEffect, useState } from "react";
+import { FC, FormEventHandler, MouseEvent, useState } from "react";
 
-import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
@@ -28,6 +26,7 @@ import AuthError from "~/client/components/auth/error";
 import Banner from "~/client/components/banner";
 import Button from "~/client/components/buttons";
 import CopiableCode from "~/client/components/copiableCode";
+import IconUpload from "~/client/components/forms/iconUpload";
 import { InputDetachedLabel } from "~/client/components/forms/input";
 import MsgBanner from "~/client/components/messageBanner";
 import Modal from "~/client/components/modal";
@@ -41,18 +40,7 @@ const ProfileSection: FC = () => {
   const auth = useAuth();
   const [displayName, setDisplayName] = useState(auth.user?.displayName ?? "");
   const [image, setImage] = useState<File | null>(null);
-  const [imageSrc, setImageSrc] = useState<string | undefined>(undefined);
   const [msg, setMsg] = useState<Msg>(null);
-
-  useEffect(() => {
-    if (!image) {
-      setImageSrc(undefined);
-      return;
-    }
-    setImageSrc(URL.createObjectURL(image));
-    return () => URL.revokeObjectURL(imageSrc!);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [image]);
 
   const handleDisplayNameSubmit: FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault();
@@ -113,52 +101,11 @@ const ProfileSection: FC = () => {
         </RightAligned>
       </form>
       <form className="flex flex-col gap-6" onSubmit={handlePhotoSubmit}>
-        <div className="flex flex-row items-start gap-6">
-          <div className="flex-grow">
-            <div className="font-semibold mb-3">Profile image</div>
-            <div>
-              Your profile picture is displayed on your replies to comments. It is also used as your
-              general profile picture in this site.
-            </div>
-          </div>
-          <div className="min-w-min">
-            <label className="cursor-pointer block w-18 md:w-24 overflow-hidden">
-              {imageSrc ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={imageSrc ?? "/images/default-photo.svg"}
-                  alt="Photo"
-                  className="w-18 h-18 md:w-24 md:h-24 rounded-full"
-                />
-              ) : (
-                <div
-                  className={clsx(
-                    "w-18 h-18 md:w-24 md:h-24 rounded-full flex flex-col justify-center items-center transition",
-                    "border border-dashed border-card text-neutral-300 dark:text-neutral-700 hover:text-muted"
-                  )}
-                >
-                  <AddOutlinedIcon fontSize="large" />
-                  <div className="hidden md:block text-xs">upload</div>
-                </div>
-              )}
-              <input
-                type="file"
-                onChange={event => {
-                  if (
-                    !event.target.files ||
-                    event.target.files.length === 0 ||
-                    !(event.target.files[0] instanceof File) ||
-                    !/\.(jpe?g|png)$/i.test(event.target.files[0].name)
-                  )
-                    setImage(null);
-                  else setImage(event.target.files[0]);
-                }}
-                className="hidden"
-                accept=".jpg, .jpeg, .png"
-              />
-            </label>
-          </div>
-        </div>
+        <IconUpload
+          label="Profile photo"
+          helpText="Your profile picture is displayed on your replies to comments. It is also used as your general profile picture in this site."
+          onUpdate={setImage}
+        />
         <RightAligned>
           <Button icon={SaveOutlinedIcon} disabled={!image}>
             Save

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -11,6 +11,7 @@ import useBreakpoint from "~/client/hooks/breakpoint";
 import { internalSWRGenerator } from "~/client/lib/fetcher";
 
 import A from "~/client/components/anchor";
+import BlankIllustration from "~/client/components/blankIllustration";
 import Button from "~/client/components/buttons";
 import Input from "~/client/components/forms/input";
 import Select from "~/client/components/forms/select";
@@ -36,46 +37,9 @@ const Loading: FC = () => (
 
 const EmptyState: FC = () => (
   <div className="flex flex-col md:flex-row items-center md:justify-center my-12 md:my-18 gap-12 md:gap-18">
-    <svg
-      className={clsx(
-        "text-neutral-300 dark:text-neutral-700 flex-shrink-0",
-        "w-[calc(286px/1.5)] sm:w-[256px] h-[calc(256px/1.5)] sm:h-[256px]"
-      )}
-      viewBox="0 0 286 256"
-    >
-      <path
-        d="M195.5 0.5C247.25 0.5 285.5 35.6553 285.5 75.3467C285.5 112.97 253.154 135.309 236.369 142.364C235.035 142.925 234.492 144.56 235.271 145.789L255.051 176.998C256.294 178.959 254.15 181.31 252.107 180.226L195.992 150.454C195.669 150.283 195.305 150.194 194.94 150.192C143.474 149.94 105.5 114.895 105.5 75.3467C105.5 35.6553 143.75 0.5 195.5 0.5Z"
-        className="stroke-card fill-card stroke-1"
-      />
-      <rect
-        width="90"
-        height="12"
-        rx="4"
-        transform="matrix(-1 0 0 1 240.5 48.5)"
-        className="fill-current"
-      />
-      <rect
-        width="90"
-        height="12"
-        rx="4"
-        transform="matrix(-1 0 0 1 240.5 69.5)"
-        className="fill-current"
-      />
-      <rect
-        width="90"
-        height="12"
-        rx="4"
-        transform="matrix(-1 0 0 1 240.5 90.5)"
-        className="fill-current"
-      />
-      <path
-        d="M90.5 75.5C38.75 75.5 0.5 110.655 0.5 150.347C0.5 187.97 32.8458 210.309 49.6308 217.364C50.9653 217.925 51.5077 219.56 50.7292 220.789L30.949 251.998C29.7059 253.959 31.8497 256.31 33.8929 255.226L90.0079 225.454C90.3313 225.283 90.6949 225.194 91.06 225.192C142.526 224.94 180.5 189.895 180.5 150.347C180.5 110.655 142.25 75.5 90.5 75.5Z"
-        className="stroke-card fill-card stroke-1"
-      />
-      <rect x="45.5" y="123.5" width="90" height="12" rx="4" className="fill-current" />
-      <rect x="45.5" y="144.5" width="90" height="12" rx="4" className="fill-current" />
-      <rect x="45.5" y="165.5" width="90" height="12" rx="4" className="fill-current" />
-    </svg>
+    <div className="flex-shrink-0 w-[calc(286px/1.5)] sm:w-[256px]">
+      <BlankIllustration />
+    </div>
     <div className="flex flex-col gap-9 justify-center">
       <div className="text-2xl sm:text-4xl text-center md:text-left">
         Add a new site to get&nbsp;started

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -114,6 +114,63 @@ const Dashboard: NextPageWithLayout<Props> = ({ sites }) => {
     return () => window.removeEventListener("resize", update);
   }, []);
 
+  if (false) {
+    return (
+      <div className="flex flex-col md:flex-row items-center md:justify-center my-12 md:my-18 gap-12 md:gap-18">
+        <svg
+          className={clsx(
+            "text-neutral-300 dark:text-neutral-700 flex-shrink-0",
+            "w-[calc(286px/1.5)] sm:w-[256px] h-[calc(256px/1.5)] sm:h-[256px]"
+          )}
+          viewBox="0 0 286 256"
+        >
+          <path
+            d="M195.5 0.5C247.25 0.5 285.5 35.6553 285.5 75.3467C285.5 112.97 253.154 135.309 236.369 142.364C235.035 142.925 234.492 144.56 235.271 145.789L255.051 176.998C256.294 178.959 254.15 181.31 252.107 180.226L195.992 150.454C195.669 150.283 195.305 150.194 194.94 150.192C143.474 149.94 105.5 114.895 105.5 75.3467C105.5 35.6553 143.75 0.5 195.5 0.5Z"
+            className="stroke-card fill-card stroke-1"
+          />
+          <rect
+            width="90"
+            height="12"
+            rx="4"
+            transform="matrix(-1 0 0 1 240.5 48.5)"
+            className="fill-current"
+          />
+          <rect
+            width="90"
+            height="12"
+            rx="4"
+            transform="matrix(-1 0 0 1 240.5 69.5)"
+            className="fill-current"
+          />
+          <rect
+            width="90"
+            height="12"
+            rx="4"
+            transform="matrix(-1 0 0 1 240.5 90.5)"
+            className="fill-current"
+          />
+          <path
+            d="M90.5 75.5C38.75 75.5 0.5 110.655 0.5 150.347C0.5 187.97 32.8458 210.309 49.6308 217.364C50.9653 217.925 51.5077 219.56 50.7292 220.789L30.949 251.998C29.7059 253.959 31.8497 256.31 33.8929 255.226L90.0079 225.454C90.3313 225.283 90.6949 225.194 91.06 225.192C142.526 224.94 180.5 189.895 180.5 150.347C180.5 110.655 142.25 75.5 90.5 75.5Z"
+            className="stroke-card fill-card stroke-1"
+          />
+          <rect x="45.5" y="123.5" width="90" height="12" rx="4" className="fill-current" />
+          <rect x="45.5" y="144.5" width="90" height="12" rx="4" className="fill-current" />
+          <rect x="45.5" y="165.5" width="90" height="12" rx="4" className="fill-current" />
+        </svg>
+        <div className="flex flex-col gap-9 justify-center">
+          <div className="text-2xl sm:text-4xl text-center md:text-left">
+            Add a new site to get&nbsp;started
+          </div>
+          <div className="text-center md:text-left">
+            <Button href="/app/new" className="inline-block" icon={AddOutlinedIcon}>
+              Add a new site
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -78,8 +78,8 @@ const SiteCard: FC<{ site?: Site }> = ({ site }) => (
             />
           </div>
           <div>
-            <div className="text-xl font-semibold mb-1">{site.name}</div>
-            <div className="text-sm text-muted">{site.domain}</div>
+            <div className="text-xl font-semibold truncate mb-1">{site.name}</div>
+            <div className="text-sm text-muted truncate">{site.domain}</div>
           </div>
         </div>
         <div className="grid grid-cols-3 gap-3">

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import { FC } from "react";
-import useSWR from "swr";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
@@ -8,7 +7,6 @@ import SortOutlinedIcon from "@mui/icons-material/SortOutlined";
 
 import useAuth from "~/client/hooks/auth";
 import useBreakpoint from "~/client/hooks/breakpoint";
-import { internalSWRGenerator } from "~/client/lib/fetcher";
 
 import A from "~/client/components/anchor";
 import BlankIllustration from "~/client/components/blankIllustration";
@@ -137,16 +135,8 @@ function showEmptyCard(breakpoint: Breakpoint, siteCount: number) {
 const Dashboard: NextPageWithLayout = () => {
   const { user } = useAuth();
   const breakpoint = useBreakpoint();
-
-  const { data } = useSWR(
-    user ? `/api/users/${user.uid}/sites` : null,
-    internalSWRGenerator<Site[] | "waiting">(),
-    { fallbackData: "waiting" }
-  );
-
-  if (!data || data === "waiting") return <Loading />;
-  if (data.length === 0) return <EmptyState />;
-
+  if (!user) return <Loading />;
+  if (user.sites.length === 0) return <EmptyState />;
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -173,10 +163,10 @@ const Dashboard: NextPageWithLayout = () => {
         </div>
       </div>
       <main className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {data.map((site, i) => (
+        {user.sites.map((site, i) => (
           <SiteCard site={site} key={i} />
         ))}
-        {showEmptyCard(breakpoint, data.length) && <EmptyCard />}
+        {showEmptyCard(breakpoint, user.sites.length) && <EmptyCard />}
       </main>
     </>
   );

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -91,9 +91,7 @@ const EmptyCard: FC = () => (
   </A>
 );
 
-const Dashboard: NextPageWithLayout<Props> = ({ sites }) => {
-  const breakpoint = useBreakpoint();
-
+function useEmptyCard() {
   const [showEmptyCard, setShowEmptyCard] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const lastCardRef = useRef<HTMLAnchorElement>(null);
@@ -113,6 +111,12 @@ const Dashboard: NextPageWithLayout<Props> = ({ sites }) => {
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
   }, []);
+  return { showEmptyCard, containerRef, lastCardRef };
+}
+
+const Dashboard: NextPageWithLayout<Props> = ({ sites }) => {
+  const breakpoint = useBreakpoint();
+  const { showEmptyCard, containerRef, lastCardRef } = useEmptyCard();
 
   if (false) {
     return (

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -60,12 +60,12 @@ const SiteCard = forwardRef<HTMLAnchorElement, { site?: Site }>(({ site }, ref) 
             <div className="w-12 h-12 rounded-full pulse" />
           </div>
           <div>
-            <div className="h-6 w-36 rounded pulse mb-1" />
-            <div className="h-4 w-32 rounded pulse" />
+            <div className="h-6 w-36 pulse mb-1" />
+            <div className="h-4 w-32 pulse" />
           </div>
         </div>
-        <div className="h-7 rounded pulse mb-3" />
-        <div className="h-4 rounded pulse" />
+        <div className="h-7 pulse mb-3" />
+        <div className="h-4 pulse" />
       </>
     )}
   </A>
@@ -155,9 +155,9 @@ const Dashboard: NextPageWithLayout<Props> = ({ sites }) => {
 const Loading: FC = () => (
   <>
     <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-      <div className="col-span-2 h-9 rounded pulse" />
-      <div className="col-span-1 h-9 rounded pulse" />
-      <div className="col-span-1 h-9 rounded pulse" />
+      <div className="col-span-2 h-9 pulse" />
+      <div className="col-span-1 h-9 pulse" />
+      <div className="col-span-1 h-9 pulse" />
     </div>
     <main className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6">
       {[...Array(16)].map((_, i) => (

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -175,7 +175,7 @@ const Dashboard: NextPageWithLayout = () => {
   const breakpoint = useBreakpoint();
 
   const { data } = useSWR(
-    user ? { url: `/api/users/${user.uid}/sites` } : null,
+    user ? `/api/users/${user.uid}/sites` : null,
     internalSWRGenerator<Site[] | "waiting">(),
     { fallbackData: "waiting" }
   );

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -195,11 +195,11 @@ const Dashboard: NextPageWithLayout = () => {
 
   const { data } = useSWR(
     user ? { url: `/api/users/${user.uid}/sites` } : null,
-    internalSWRGenerator<Site[]>(),
-    { fallbackData: [] }
+    internalSWRGenerator<Site[] | "waiting">(),
+    { fallbackData: "waiting" }
   );
 
-  if (!data) return <Loading />;
+  if (!data || data === "waiting") return <Loading />;
   if (data.length === 0) return <EmptyState />;
 
   return (

--- a/pages/app/dashboard.tsx
+++ b/pages/app/dashboard.tsx
@@ -17,7 +17,6 @@ import Select from "~/client/components/forms/select";
 import AppLayout from "~/client/layouts/app";
 
 import { NextPageWithLayout } from "~/types/client/utils.type";
-import { FetchOptions } from "~/types/client/utils.type";
 import { Site } from "~/types/server";
 
 const Loading: FC = () => (

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -1,3 +1,5 @@
+import { FC } from "react";
+
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
@@ -47,8 +49,25 @@ const New: NextPageWithLayout = () => (
   </div>
 );
 
+const Loading: FC = () => (
+  <div className="mx-auto max-w-lg">
+    <div className="pulse h-9 w-48 mb-6" />
+    <div className="pulse h-4 mb-3" />
+    <div className="pulse h-4 mb-6" />
+    <div className="pulse h-6 w-48 mb-3" />
+    <div className="pulse h-9 mb-3" />
+    <div className="pulse h-4 mb-3" />
+    <div className="pulse h-4 mb-6" />
+    <div className="pulse h-6 w-48 mb-3" />
+    <div className="pulse h-9 mb-3" />
+    <div className="pulse h-4 mb-3" />
+    <div className="pulse h-4 mb-6" />
+    <div className="pulse h-9 mb-3" />
+  </div>
+);
+
 New.getLayout = page => (
-  <AppLayout title="Add a new site" type="overview" activeTab="new">
+  <AppLayout title="Add a new site" type="overview" activeTab="new" loadingScreen={<Loading />}>
     {page}
   </AppLayout>
 );

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import { FC, FormEventHandler, useState } from "react";
-import isSlug from "validator/lib/isSlug";
-import isURL from "validator/lib/isURL";
+import { SITE } from "~/misc/validate";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
@@ -27,9 +26,6 @@ const New: NextPageWithLayout = () => {
   const [domain, setDomain] = useState("");
   const [msg, setMsg] = useState<Msg>(null);
 
-  const nameIsValid = () => isSlug(name);
-  const domainIsValid = () => isURL(domain, { require_protocol: true });
-
   const createNewSite = async (name: string, domain: string) => {
     setLoading(true);
     if (!user) throw E.NOT_AUTHENTICATED;
@@ -46,7 +42,7 @@ const New: NextPageWithLayout = () => {
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async event => {
     event.preventDefault();
-    if (!nameIsValid() || !domainIsValid()) return;
+    if (!SITE.nameIsValid(name) || !SITE.domainIsValid(domain)) return;
     try {
       await createNewSite(name, domain);
     } catch (err: any) {
@@ -71,7 +67,7 @@ const New: NextPageWithLayout = () => {
           required
           value={name}
           onChange={event => setName(event.target.value)}
-          isInvalid={(name.length > 0 || domain.length > 0) && !nameIsValid()}
+          isInvalid={(name.length > 0 || domain.length > 0) && !SITE.nameIsValid(name)}
           helpText={
             <>
               The site name helps identify this site with other sites you also have. It can only
@@ -81,13 +77,13 @@ const New: NextPageWithLayout = () => {
           }
         />
         <InputDetachedLabel
-          label="Site hostname"
+          label="Site domain with protocol"
           type="text"
           icon={WebOutlinedIcon}
           required
           value={domain}
           onChange={event => setDomain(event.target.value)}
-          isInvalid={(name.length > 0 || domain.length > 0) && !domainIsValid()}
+          isInvalid={(name.length > 0 || domain.length > 0) && !SITE.domainIsValid(domain)}
           placeholder="https://example.com, https://mysite.example.com, &hellip;"
           helpText={
             <>
@@ -100,7 +96,10 @@ const New: NextPageWithLayout = () => {
             </>
           }
         />
-        <Button icon={AddOutlinedIcon} disabled={!(nameIsValid() && domainIsValid())}>
+        <Button
+          icon={AddOutlinedIcon}
+          disabled={!(SITE.nameIsValid(name) && SITE.domainIsValid(domain))}
+        >
           Add a new site
         </Button>
       </form>

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -1,4 +1,6 @@
-import { FC } from "react";
+import { FC, FormEventHandler, useState } from "react";
+import isSlug from "validator/es/lib/isSlug";
+import isURL from "validator/es/lib/isURL";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
@@ -11,43 +13,66 @@ import AppLayout from "~/client/layouts/app";
 
 import { NextPageWithLayout } from "~/types/client/utils.type";
 
-const New: NextPageWithLayout = () => (
-  <div className="mx-auto max-w-lg">
-    <h1>Add a new site</h1>
-    <p>
-      A new site let you host comments for all webpages under any domain or subdomain.{" "}
-      <A href="https://google.com">Should I create a new site or page?</A>
-    </p>
-    <form className="flex flex-col gap-6">
-      <InputDetachedLabel
-        label="Site name"
-        type="text"
-        icon={LabelOutlinedIcon}
-        required
-        helpText={
-          <>
-            The site name helps identify this site with other sites you also have. It can only
-            contain lowercase letters, digits and hyphens. It must start with a letter.
-          </>
-        }
-      />
-      <InputDetachedLabel
-        label="Site domain"
-        type="text"
-        icon={WebOutlinedIcon}
-        required
-        placeholder="example.com, mysite.example.com, &hellip;"
-        helpText={
-          <>
-            The domain is where you want to host the comments. It can be any domain or subdomain.
-            Other websites will not be allowed to host the comments.
-          </>
-        }
-      />
-      <Button icon={AddOutlinedIcon}>Add a new site</Button>
-    </form>
-  </div>
-);
+const New: NextPageWithLayout = () => {
+  const [name, setName] = useState("");
+  const [domain, setDomain] = useState("");
+  const nameIsValid = () => isSlug(name);
+  const domainIsValid = () => isURL(domain, { require_protocol: true });
+  const handleSubmit: FormEventHandler<HTMLFormElement> = event => {
+    event.preventDefault();
+    if (!nameIsValid() || !domainIsValid()) return;
+  };
+  return (
+    <div className="mx-auto md:max-w-lg">
+      <h1>Add a new site</h1>
+      <p>
+        A new site let you host comments for all webpages under any domain or subdomain.{" "}
+        <A href="https://google.com">Should I create a new site or page?</A>
+      </p>
+      <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
+        <InputDetachedLabel
+          label="Site name"
+          type="text"
+          icon={LabelOutlinedIcon}
+          required
+          value={name}
+          onChange={event => setName(event.target.value)}
+          isInvalid={!nameIsValid()}
+          helpText={
+            <>
+              The site name helps identify this site with other sites you also have. It can only
+              contain lowercase letters, digits and hyphens. It must start with a letter and be at
+              least 3 characters long.
+            </>
+          }
+        />
+        <InputDetachedLabel
+          label="Site hostname"
+          type="text"
+          icon={WebOutlinedIcon}
+          required
+          value={domain}
+          onChange={event => setDomain(event.target.value)}
+          isInvalid={!domainIsValid()}
+          placeholder="https://example.com, https://mysite.example.com, &hellip;"
+          helpText={
+            <>
+              The hostname of the website where you want to host the comments. It can be any domain
+              or subdomain with a valid protocol. Other websites{" "}
+              <A href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors">
+                will not be allowed to host the comments
+              </A>
+              .
+            </>
+          }
+        />
+        <Button icon={AddOutlinedIcon} disabled={!(nameIsValid() && domainIsValid())}>
+          Add a new site
+        </Button>
+      </form>
+    </div>
+  );
+};
 
 const Loading: FC = () => (
   <div className="mx-auto max-w-lg">

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -10,7 +10,7 @@ import { SITE } from "~/misc/validate";
 import * as E from "~/client/lib/errors";
 import useAuth from "~/client/hooks/auth";
 import { internalFetcher } from "~/client/lib/fetcher";
-import { getUser } from "~/client/lib/firebase/auth";
+import { refreshUser } from "~/client/lib/firebase/auth";
 
 import A from "~/client/components/anchor";
 import AuthError from "~/client/components/auth/error";
@@ -22,7 +22,7 @@ import AppLayout from "~/client/layouts/app";
 import { ResponseMessage as Msg, NextPageWithLayout } from "~/types/client/utils.type";
 
 const New: NextPageWithLayout = () => {
-  const { user, setUser, setLoading } = useAuth();
+  const { user, setUser, loading, setLoading } = useAuth();
   const router = useRouter();
   const [name, setName] = useState("");
   const [domain, setDomain] = useState("");
@@ -39,8 +39,7 @@ const New: NextPageWithLayout = () => {
     });
     if (status === 409) throw E.SITE_ALREADY_EXISTS;
     if (!success) throw E.UNABLE_TO_CREATE_SITE;
-    const newUser = await getUser();
-    setUser(newUser);
+    await refreshUser({ user, setUser, loading, setLoading });
     setLoading(false);
     router.push(`/app/site/${name}`);
   };

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -33,11 +33,12 @@ const New: NextPageWithLayout = () => {
   const createNewSite = async (name: string, domain: string) => {
     setLoading(true);
     if (!user) throw E.NOT_AUTHENTICATED;
-    const { success } = await internalFetcher({
+    const { success, status } = await internalFetcher({
       url: `/api/users/${user.uid}/sites`,
       method: "POST",
       options: { body: JSON.stringify({ name, domain }) },
     });
+    if (status === 409) throw E.SITE_ALREADY_EXISTS;
     if (!success) throw E.UNABLE_TO_CREATE_SITE;
     setLoading(false);
     router.push("/app/dashboard"); // TODO: redirect to the site dashboard instead

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -10,6 +10,7 @@ import { SITE } from "~/misc/validate";
 import * as E from "~/client/lib/errors";
 import useAuth from "~/client/hooks/auth";
 import { internalFetcher } from "~/client/lib/fetcher";
+import { getUser } from "~/client/lib/firebase/auth";
 
 import A from "~/client/components/anchor";
 import AuthError from "~/client/components/auth/error";
@@ -21,7 +22,7 @@ import AppLayout from "~/client/layouts/app";
 import { ResponseMessage as Msg, NextPageWithLayout } from "~/types/client/utils.type";
 
 const New: NextPageWithLayout = () => {
-  const { user, setLoading } = useAuth();
+  const { user, setUser, setLoading } = useAuth();
   const router = useRouter();
   const [name, setName] = useState("");
   const [domain, setDomain] = useState("");
@@ -30,6 +31,7 @@ const New: NextPageWithLayout = () => {
   const createNewSite = async (name: string, domain: string) => {
     setLoading(true);
     if (!user) throw E.NOT_AUTHENTICATED;
+    if (user.sites.find(s => s.name === name)) throw E.SITE_ALREADY_EXISTS;
     const { success, status } = await internalFetcher({
       url: `/api/users/${user.uid}/sites`,
       method: "POST",
@@ -37,8 +39,10 @@ const New: NextPageWithLayout = () => {
     });
     if (status === 409) throw E.SITE_ALREADY_EXISTS;
     if (!success) throw E.UNABLE_TO_CREATE_SITE;
+    const newUser = await getUser();
+    setUser(newUser);
     setLoading(false);
-    router.push("/app/dashboard"); // TODO: redirect to the site dashboard instead
+    router.push(`/app/site/${name}`);
   };
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async event => {

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -1,6 +1,6 @@
 import { FC, FormEventHandler, useState } from "react";
-import isSlug from "validator/es/lib/isSlug";
-import isURL from "validator/es/lib/isURL";
+import isSlug from "validator/lib/isSlug";
+import isURL from "validator/lib/isURL";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
@@ -37,7 +37,7 @@ const New: NextPageWithLayout = () => {
           required
           value={name}
           onChange={event => setName(event.target.value)}
-          isInvalid={!nameIsValid()}
+          isInvalid={(name.length > 0 || domain.length > 0) && !nameIsValid()}
           helpText={
             <>
               The site name helps identify this site with other sites you also have. It can only
@@ -53,7 +53,7 @@ const New: NextPageWithLayout = () => {
           required
           value={domain}
           onChange={event => setDomain(event.target.value)}
-          isInvalid={!domainIsValid()}
+          isInvalid={(name.length > 0 || domain.length > 0) && !domainIsValid()}
           placeholder="https://example.com, https://mysite.example.com, &hellip;"
           helpText={
             <>

--- a/pages/app/new.tsx
+++ b/pages/app/new.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from "next/router";
 import { FC, FormEventHandler, useState } from "react";
-import { SITE } from "~/misc/validate";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
+
+import { SITE } from "~/misc/validate";
 
 import * as E from "~/client/lib/errors";
 import useAuth from "~/client/hooks/auth";

--- a/pages/app/site/[siteName]/customise.tsx
+++ b/pages/app/site/[siteName]/customise.tsx
@@ -66,7 +66,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({ buttons, active }) => (
   </div>
 );
 
-const Content: FC<{ siteId: string }> = ({ siteId }) => {
+const Content: FC = () => {
   const currentTheme = useTheme();
   const breakpoint = useBreakpoint();
 

--- a/pages/app/site/[siteName]/customise.tsx
+++ b/pages/app/site/[siteName]/customise.tsx
@@ -5,7 +5,6 @@
  */
 import Editor from "@monaco-editor/react";
 import clsx from "clsx";
-import { GetServerSideProps } from "next";
 import { FC, useState } from "react";
 
 import ColourOutlinedIcon from "@mui/icons-material/ColorLensOutlined";
@@ -20,20 +19,16 @@ import useBreakpoint from "~/client/hooks/breakpoint";
 import useTheme from "~/client/hooks/theme";
 import generateCommentHTML from "~/client/lib/generateCommentHTML";
 
+import sitePages from "~/client/components/app/handleSite";
 import Button from "~/client/components/buttons";
 import Input from "~/client/components/forms/input";
 import SideBySide from "~/client/components/sideBySide";
 import IconLabel from "~/client/components/utils/iconAndLabel";
-import AppLayout from "~/client/layouts/app";
 
-import { IconAndLabel, NextPageWithLayout } from "~/types/client/utils.type";
+import { IconAndLabel } from "~/types/client/utils.type";
 
 import { all, comment, styles } from "~/constants/sampleCommentCode";
 
-import site from "~/sample/site.json";
-
-type Site = typeof site;
-type Props = { site: Site };
 type ButtonGroupProps = {
   buttons: (IconAndLabel & { onClick: () => void })[];
   active: number;
@@ -71,7 +66,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({ buttons, active }) => (
   </div>
 );
 
-const SiteCustomise: NextPageWithLayout<Props> = ({ site }) => {
+const Content: FC<{ siteId: string }> = ({ siteId }) => {
   const currentTheme = useTheme();
   const breakpoint = useBreakpoint();
 
@@ -170,18 +165,41 @@ const SiteCustomise: NextPageWithLayout<Props> = ({ site }) => {
   );
 };
 
-SiteCustomise.getLayout = page => (
-  <AppLayout
-    title={`Customise | ${site.name}`}
-    type="site"
-    activeTab="customise"
-    siteName={site.name}
-    removePadding
-  >
-    {page}
-  </AppLayout>
+const Loading: FC = () => (
+  <>
+    <div className="lg:hidden py-9">
+      Please use a laptop or a device with a wider screen to use this feature.
+    </div>
+    <div
+      className={clsx(
+        "hidden lg:flex flex-row gap-6 items-center",
+        "py-3 bg-neutral-100 dark:bg-neutral-900 sticky top-[49px] z-10"
+      )}
+    >
+      <div className="h-9 w-72 pulse" />
+      <div className="h-9 w-48 pulse" />
+      <div className="h-9 w-36 pulse" />
+      <div className="flex-grow" />
+      <div className="h-9 w-24 pulse" />
+      <div className="h-9 w-24 pulse" />
+    </div>
+    <div className="hidden lg:grid grid-cols-2 gap-6 mb-9">
+      <div className="h-[90vh] pulse" />
+      <div className="h-[90vh] pulse" />
+    </div>
+  </>
 );
 
-export const getServerSideProps: GetServerSideProps<Props> = async () => ({ props: { site } });
+const {
+  Page: SiteCustomise,
+  getStaticPaths,
+  getStaticProps,
+} = sitePages({
+  title: siteName => `Customise | ${siteName}`,
+  activeTab: "customise",
+  removePadding: true,
+  Loading,
+  Content,
+});
 
-export default SiteCustomise;
+export { SiteCustomise as default, getStaticPaths, getStaticProps };

--- a/pages/app/site/[siteName]/customise.tsx
+++ b/pages/app/site/[siteName]/customise.tsx
@@ -195,11 +195,7 @@ const Loading: FC = () => (
   </>
 );
 
-const {
-  Page: SiteCustomise,
-  getStaticPaths,
-  getStaticProps,
-} = sitePages({
+const SiteCustomise = sitePages({
   title: siteName => `Customise | ${siteName}`,
   activeTab: "customise",
   removePadding: true,
@@ -207,4 +203,4 @@ const {
   Content,
 });
 
-export { SiteCustomise as default, getStaticPaths, getStaticProps };
+export default SiteCustomise;

--- a/pages/app/site/[siteName]/customise.tsx
+++ b/pages/app/site/[siteName]/customise.tsx
@@ -20,6 +20,7 @@ import useTheme from "~/client/hooks/theme";
 import generateCommentHTML from "~/client/lib/generateCommentHTML";
 
 import sitePages from "~/client/components/app/handleSite";
+import BlankIllustration from "~/client/components/blankIllustration";
 import Button from "~/client/components/buttons";
 import Input from "~/client/components/forms/input";
 import SideBySide from "~/client/components/sideBySide";
@@ -77,8 +78,12 @@ const Content: FC = () => {
 
   return (
     <>
-      <div className="lg:hidden py-9">
-        Please use a laptop or a device with a wider screen to use this feature.
+      <div className="lg:hidden flex flex-col gap-6 my-12 items-center">
+        <div className="w-48">
+          <BlankIllustration />
+        </div>
+        <div className="text-xl text-center">Oops! Your screen is too small.</div>
+        <div>Please use a laptop or a device with a wider screen to use this feature.</div>
       </div>
       <div
         className={clsx(

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -112,11 +112,11 @@ const Content: FC = () => {
           <Button
             icon={CodeOutlinedIcon}
             variant="tertiary"
-            href={`/app/site/${site.id}/customise`}
+            href={`/app/site/${site.name}/customise`}
           >
             Customise
           </Button>
-          <Button icon={SettingsOutlinedIcon} href={`/app/site/${site.id}/settings`}>
+          <Button icon={SettingsOutlinedIcon} href={`/app/site/${site.name}/settings`}>
             Manage
           </Button>
         </div>

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -231,10 +231,10 @@ const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
 
 SiteOverview.getLayout = (page, { siteName }) => (
   <AppLayout
-    title={siteName ?? "Loading"}
+    title={siteName}
     type="site"
     activeTab="all"
-    siteName={siteName ?? "Loading"}
+    siteName={siteName}
     loadingScreen={<Loading />}
   >
     {page}

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -228,14 +228,8 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
 const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
   const { user } = useAuth();
   const router = useRouter();
-  const { data } = useSWR(
-    user ? `/api/users/${user.uid}/sites` : null,
-    internalSWRGenerator<Site[] | null>(),
-    { fallbackData: null }
-  );
-  if (!data) return <Loading />;
-
-  const site = data.find(s => s.name === siteName);
+  if (!user) return <Loading />;
+  const site = user.sites.find(s => s.name === siteName);
   if (!site) {
     // I'm not even sure if this is the recommended way to do a "client-side" 404, but it works and
     // it is *not* a workaround (I think).

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -1,6 +1,5 @@
 // import clsx from "clsx";
 import { FC, useState } from "react";
-import useSWR from "swr";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
@@ -9,9 +8,9 @@ import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
 // import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 
-// import useBreakpoint from "~/client/hooks/breakpoint";
-import { internalSWRGenerator } from "~/client/lib/fetcher";
+import { useSite } from "~/client/hooks/site";
 
+// import useBreakpoint from "~/client/hooks/breakpoint";
 import A from "~/client/components/anchor";
 import sitePages from "~/client/components/app/handleSite";
 import BlankIllustration from "~/client/components/blankIllustration";
@@ -21,8 +20,6 @@ import { InputDetachedLabel } from "~/client/components/forms/input";
 import Modal from "~/client/components/modal";
 // import SiteGraph from "~/client/components/siteGraph";
 import RightAligned from "~/client/components/utils/rightAligned";
-
-import { Site } from "~/types/server";
 
 const Loading: FC = () => (
   <>
@@ -78,12 +75,10 @@ const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, l
 );
 */
 
-const Content: FC<{ siteId: string }> = ({ siteId }) => {
+const Content: FC = () => {
   // const breakpoint = useBreakpoint();
   const [showNewPageModal, setShowNewPageModal] = useState(false);
-  const { data: site } = useSWR(`/api/sites/${siteId}`, internalSWRGenerator<Site | null>(), {
-    fallbackData: null,
-  });
+  const { site } = useSite();
   if (!site) return <Loading />;
   return (
     <>

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -1,24 +1,24 @@
-import clsx from "clsx";
+// import clsx from "clsx";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { FC, useState } from "react";
 import useSWR from "swr";
-import Error404 from "~/pages/404";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
-import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
+// import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 
 import useAuth from "~/client/hooks/auth";
-import useBreakpoint from "~/client/hooks/breakpoint";
+// import useBreakpoint from "~/client/hooks/breakpoint";
 import { internalSWRGenerator } from "~/client/lib/fetcher";
 
 import A from "~/client/components/anchor";
+import BlankIllustration from "~/client/components/blankIllustration";
 import Button from "~/client/components/buttons";
-import Input from "~/client/components/forms/input";
+// import Input from "~/client/components/forms/input";
 import { InputDetachedLabel } from "~/client/components/forms/input";
 import Modal from "~/client/components/modal";
 // import SiteGraph from "~/client/components/siteGraph";
@@ -74,6 +74,7 @@ const Loading: FC = () => (
   </>
 );
 
+/*
 const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, label, small }) => (
   <div>
     <div className={clsx("font-light tracking-tighter", small ? "text-3xl" : "text-4xl")}>
@@ -82,9 +83,10 @@ const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, l
     <div className={clsx("text-muted", small && "text-sm")}>{label}</div>
   </div>
 );
+*/
 
 const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
-  const breakpoint = useBreakpoint();
+  // const breakpoint = useBreakpoint();
   const [showNewPageModal, setShowNewPageModal] = useState(false);
   const { data: site } = useSWR(`/api/sites/${siteId}`, internalSWRGenerator<Site | null>(), {
     fallbackData: null,
@@ -131,6 +133,24 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
           </Button>
         </div>
       </div>
+      <div className="flex flex-col gap-6 my-12 items-center">
+        <div className="w-48">
+          <BlankIllustration />
+        </div>
+        <div className="text-xl text-center">
+          Create a new page to start collecting&nbsp;comments.
+        </div>
+        <div>
+          <Button
+            icon={AddOutlinedIcon}
+            onClick={() => setShowNewPageModal(true)}
+            className="inline-block"
+          >
+            Add a new page
+          </Button>
+        </div>
+      </div>
+      {/*
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-x-12 gap-y-9">
         <div className="lg:col-span-5">
           <div className="grid grid-cols-3">
@@ -139,7 +159,7 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
             <Stats label="pending" value={0} />
           </div>
           <h2>Last 30 days</h2>
-          {/* <SiteGraph {...site.statistics} /> */}
+          <SiteGraph {...site.statistics} />
         </div>
         <div className="lg:col-span-7">
           <h2>All pages</h2>
@@ -156,41 +176,8 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
             >
               {breakpoint === "xs" ? "New page" : "Add a new page"}
             </Button>
-            <Modal isVisible={showNewPageModal} onOutsideClick={() => setShowNewPageModal(false)}>
-              <div className="p-6 max-w-lg">
-                <h2>Add a new page</h2>
-                <p>
-                  Please fill in these information as they helps identify this page from other pages
-                  in the same site.
-                </p>
-                <form className="flex flex-col gap-6">
-                  <InputDetachedLabel
-                    label="Page title"
-                    icon={LabelOutlinedIcon}
-                    type="text"
-                    required
-                  />
-                  <InputDetachedLabel
-                    label="Page URL"
-                    icon={WebOutlinedIcon}
-                    type="text"
-                    required
-                  />
-                  <RightAligned className="gap-6">
-                    <Button
-                      variant="tertiary"
-                      onClick={() => setShowNewPageModal(false)}
-                      type="button"
-                    >
-                      Cancel
-                    </Button>
-                    <Button>Create</Button>
-                  </RightAligned>
-                </form>
-              </div>
-            </Modal>
           </div>
-          {/* <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-6">
             {site.pages.map((page, i) => (
               <A
                 notStyled
@@ -211,9 +198,29 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
                 </div>
               </A>
             ))}
-            </div> */}
+            </div>
         </div>
       </div>
+      */}
+      <Modal isVisible={showNewPageModal} onOutsideClick={() => setShowNewPageModal(false)}>
+        <div className="p-6 max-w-lg">
+          <h2>Add a new page</h2>
+          <p>
+            Please fill in these information as they helps identify this page from other pages in
+            the same site.
+          </p>
+          <form className="flex flex-col gap-6">
+            <InputDetachedLabel label="Page title" icon={LabelOutlinedIcon} type="text" required />
+            <InputDetachedLabel label="Page URL" icon={WebOutlinedIcon} type="text" required />
+            <RightAligned className="gap-6">
+              <Button variant="tertiary" onClick={() => setShowNewPageModal(false)} type="button">
+                Cancel
+              </Button>
+              <Button>Create</Button>
+            </RightAligned>
+          </form>
+        </div>
+      </Modal>
     </>
   );
 };

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -28,6 +28,49 @@ import site from "~/sample/site.json";
 type Props = { siteName: string };
 type Param = Props;
 
+const Loading: FC = () => (
+  <>
+    <div className="flex flex-col md:flex-row justify-between items-start gap-y-6 mb-6">
+      <div className="flex flex-row gap-6 items-center">
+        <div className="rounded-full w-16 h-16 pulse" />
+        <div>
+          <div className="mb-2.5 h-8 w-36 pulse" />
+          <div className="h-4 w-48 pulse" />
+        </div>
+      </div>
+      <div className="w-full md:w-auto grid grid-cols-2 gap-6">
+        <div className="min-w-[144px] h-9 pulse" />
+        <div className="min-w-[144px] h-9 pulse" />
+      </div>
+    </div>
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-x-12 gap-y-9">
+      <div className="lg:col-span-5">
+        <div className="grid grid-cols-3 gap-9">
+          <div className="h-14 pulse" />
+          <div className="h-14 pulse" />
+          <div className="h-14 pulse" />
+        </div>
+        <div className="w-36 h-7 pulse mt-9 mb-6" />
+        <div className="aspect-h-8 aspect-w-12 md:aspect-h-6 lg:aspect-h-8 pulse" />
+      </div>
+      <div className="lg:col-span-7">
+        <div className="w-36 h-7 pulse mb-6" />
+        <div className="flex flex-row gap-6 mb-6">
+          <div className="h-9 pulse flex-1" />
+          <div className="pulse w-36" />
+        </div>
+        <div className="flex flex-col gap-6">
+          {Array(10)
+            .fill(0)
+            .map((_, i) => (
+              <div className="h-36 pulse" key={i} />
+            ))}
+        </div>
+      </div>
+    </div>
+  </>
+);
+
 const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, label, small }) => (
   <div>
     <div className={clsx("font-light tracking-tighter", small ? "text-3xl" : "text-4xl")}>
@@ -164,7 +207,13 @@ const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
 };
 
 SiteOverview.getLayout = (page, { siteName }) => (
-  <AppLayout title={siteName} type="site" activeTab="all" siteName={siteName}>
+  <AppLayout
+    title={siteName ?? "Loading"}
+    type="site"
+    activeTab="all"
+    siteName={siteName ?? "Loading"}
+    loadingScreen={<Loading />}
+  >
     {page}
   </AppLayout>
 );

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -99,7 +99,7 @@ const Content: FC = () => {
             <div className="flex flex-row gap-3 text-muted">
               <WebOutlinedIcon />
               <A
-                href={`https://${site.domain}`}
+                href={site.domain.startsWith("https://") ? site.domain : `https://${site.domain}`}
                 notStyled
                 className="hover:text-neutral-900 dark:hover:text-neutral-100 transition"
               >

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -1,6 +1,4 @@
 // import clsx from "clsx";
-import { GetStaticPaths, GetStaticProps } from "next";
-import { useRouter } from "next/router";
 import { FC, useState } from "react";
 import useSWR from "swr";
 
@@ -11,11 +9,11 @@ import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
 // import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 
-import useAuth from "~/client/hooks/auth";
 // import useBreakpoint from "~/client/hooks/breakpoint";
 import { internalSWRGenerator } from "~/client/lib/fetcher";
 
 import A from "~/client/components/anchor";
+import sitePages from "~/client/components/app/handleSite";
 import BlankIllustration from "~/client/components/blankIllustration";
 import Button from "~/client/components/buttons";
 // import Input from "~/client/components/forms/input";
@@ -23,13 +21,8 @@ import { InputDetachedLabel } from "~/client/components/forms/input";
 import Modal from "~/client/components/modal";
 // import SiteGraph from "~/client/components/siteGraph";
 import RightAligned from "~/client/components/utils/rightAligned";
-import AppLayout from "~/client/layouts/app";
 
-import { NextPageWithLayout } from "~/types/client/utils.type";
 import { Site } from "~/types/server";
-
-type Props = { siteName: string };
-type Param = Props;
 
 const Loading: FC = () => (
   <>
@@ -85,7 +78,7 @@ const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, l
 );
 */
 
-const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
+const Content: FC<{ siteId: string }> = ({ siteId }) => {
   // const breakpoint = useBreakpoint();
   const [showNewPageModal, setShowNewPageModal] = useState(false);
   const { data: site } = useSWR(`/api/sites/${siteId}`, internalSWRGenerator<Site | null>(), {
@@ -225,34 +218,10 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
   );
 };
 
-const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
-  const { user } = useAuth();
-  const router = useRouter();
-  if (!user) return <Loading />;
-  const site = user.sites.find(s => s.name === siteName);
-  if (!site) {
-    // I'm not even sure if this is the recommended way to do a "client-side" 404, but it works and
-    // it is *not* a workaround (I think).
-    router.push("/404", router.asPath);
-    return null;
-  }
-  return <SiteOverviewWithData siteId={site.id} />;
-};
+const {
+  Page: SiteOverview,
+  getStaticPaths,
+  getStaticProps,
+} = sitePages({ title: siteName => siteName, activeTab: "all", Loading, Content });
 
-SiteOverview.getLayout = (page, { siteName }) => (
-  <AppLayout
-    title={siteName ?? "Loading"}
-    type="site"
-    activeTab="all"
-    siteName={siteName}
-    loadingScreen={<Loading />}
-  >
-    {page}
-  </AppLayout>
-);
-
-export const getStaticPaths: GetStaticPaths<Param> = () => ({ paths: [], fallback: true });
-export const getStaticProps: GetStaticProps<Props, Param> = ({ params }) =>
-  params && params.siteName ? { props: { siteName: params.siteName } } : { notFound: true };
-
-export default SiteOverview;
+export { SiteOverview as default, getStaticPaths, getStaticProps };

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -1,7 +1,9 @@
 import clsx from "clsx";
 import { GetStaticPaths, GetStaticProps } from "next";
+import { useRouter } from "next/router";
 import { FC, useState } from "react";
 import useSWR from "swr";
+import Error404 from "~/pages/404";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CodeOutlinedIcon from "@mui/icons-material/CodeOutlined";
@@ -218,14 +220,21 @@ const SiteOverviewWithData: FC<{ siteId: string }> = ({ siteId }) => {
 
 const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
   const { user } = useAuth();
+  const router = useRouter();
   const { data } = useSWR(
     user ? `/api/users/${user.uid}/sites` : null,
     internalSWRGenerator<Site[] | null>(),
     { fallbackData: null }
   );
   if (!data) return <Loading />;
+
   const site = data.find(s => s.name === siteName);
-  if (!site) return <div>site not found</div>;
+  if (!site) {
+    // I'm not even sure if this is the recommended way to do a "client-side" 404, but it works and
+    // it is *not* a workaround (I think).
+    router.push("/404", router.asPath);
+    return null;
+  }
   return <SiteOverviewWithData siteId={site.id} />;
 };
 

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -241,7 +241,7 @@ const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
 
 SiteOverview.getLayout = (page, { siteName }) => (
   <AppLayout
-    title={siteName}
+    title={siteName ?? "Loading"}
     type="site"
     activeTab="all"
     siteName={siteName}

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { formatDistanceToNow, parseISO } from "date-fns";
-import { GetServerSideProps } from "next";
+import { GetServerSideProps, GetStaticPaths, GetStaticProps } from "next";
 import { FC, useState } from "react";
 
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
@@ -25,8 +25,8 @@ import { NextPageWithLayout } from "~/types/client/utils.type";
 
 import site from "~/sample/site.json";
 
-type Site = typeof site;
-type Props = { site: Site };
+type Props = { siteName: string };
+type Param = Props;
 
 const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, label, small }) => (
   <div>
@@ -37,7 +37,7 @@ const Stats: FC<{ value: number; label: string; small?: boolean }> = ({ value, l
   </div>
 );
 
-const SiteOverview: NextPageWithLayout<Props> = ({ site }) => {
+const SiteOverview: NextPageWithLayout<Props> = ({ siteName }) => {
   const breakpoint = useBreakpoint();
   const [showNewPageModal, setShowNewPageModal] = useState(false);
 
@@ -50,7 +50,7 @@ const SiteOverview: NextPageWithLayout<Props> = ({ site }) => {
             <img src={site.iconURL} alt="" width={64} height={64} loading="lazy" />
           </div>
           <div>
-            <div className="mb-1.5 text-3xl">{site.name}</div>
+            <div className="mb-1.5 text-3xl">{siteName}</div>
             <div className="flex flex-row gap-3 text-muted">
               <WebOutlinedIcon />
               <A
@@ -163,12 +163,14 @@ const SiteOverview: NextPageWithLayout<Props> = ({ site }) => {
   );
 };
 
-SiteOverview.getLayout = page => (
-  <AppLayout title={site.name} type="site" activeTab="all" siteName={site.name}>
+SiteOverview.getLayout = (page, { siteName }) => (
+  <AppLayout title={siteName} type="site" activeTab="all" siteName={siteName}>
     {page}
   </AppLayout>
 );
 
-export const getServerSideProps: GetServerSideProps<Props> = async () => ({ props: { site } });
+export const getStaticPaths: GetStaticPaths<Param> = () => ({ paths: [], fallback: true });
+export const getStaticProps: GetStaticProps<Props, Param> = ({ params }) =>
+  params && params.siteName ? { props: { siteName: params.siteName } } : { notFound: true };
 
 export default SiteOverview;

--- a/pages/app/site/[siteName]/index.tsx
+++ b/pages/app/site/[siteName]/index.tsx
@@ -213,10 +213,6 @@ const Content: FC = () => {
   );
 };
 
-const {
-  Page: SiteOverview,
-  getStaticPaths,
-  getStaticProps,
-} = sitePages({ title: siteName => siteName, activeTab: "all", Loading, Content });
+const SiteOverview = sitePages({ title: siteName => siteName, activeTab: "all", Loading, Content });
 
-export { SiteOverview as default, getStaticPaths, getStaticProps };
+export default SiteOverview;

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -15,8 +15,12 @@ import Button from "~/client/components/buttons";
 import CopiableCode from "~/client/components/copiableCode";
 import IconUpload from "~/client/components/forms/iconUpload";
 import { InputDetachedLabel } from "~/client/components/forms/input";
+import MsgBanner from "~/client/components/messageBanner";
 import Modal from "~/client/components/modal";
 import RightAligned from "~/client/components/utils/rightAligned";
+
+import { ResponseMessage as Msg } from "~/types/client/utils.type";
+import { Site } from "~/types/server";
 
 const LoadingSection: FC = () => (
   <section>
@@ -52,7 +56,10 @@ const Loading: FC = () => (
   </div>
 );
 
-const UpdateSiteName: FC<{ siteName: string }> = ({ siteName }) => {
+const UpdateSiteName: FC<{ siteName: string; setMsg: (msg: Msg) => void }> = ({
+  siteName,
+  setMsg,
+}) => {
   const [name, setName] = useState(siteName);
   return (
     <form className="flex flex-col gap-6">
@@ -75,7 +82,10 @@ const UpdateSiteName: FC<{ siteName: string }> = ({ siteName }) => {
   );
 };
 
-const UpdateSiteDomain: FC<{ siteDomain: string }> = ({ siteDomain }) => {
+const UpdateSiteDomain: FC<{ siteDomain: string; setMsg: (msg: Msg) => void }> = ({
+  siteDomain,
+  setMsg,
+}) => {
   const [domain, setDomain] = useState(siteDomain);
   return (
     <form className="flex flex-col gap-6">
@@ -101,7 +111,7 @@ const UpdateSiteDomain: FC<{ siteDomain: string }> = ({ siteDomain }) => {
   );
 };
 
-const UploadSiteIcon: FC = () => {
+const UploadSiteIcon: FC<{ setMsg: (msg: Msg) => void }> = ({ setMsg }) => {
   const [icon, setIcon] = useState<File | null>(null);
   return (
     <form className="flex flex-col gap-6">
@@ -119,6 +129,21 @@ const UploadSiteIcon: FC = () => {
   );
 };
 
+const UpdateSite: FC<{ site: Site }> = ({ site }) => {
+  const [msg, setMsg] = useState<Msg>(null);
+  return (
+    <section>
+      <h2>Basic information</h2>
+      {msg && <MsgBanner msg={msg} />}
+      <div className="flex flex-col gap-12">
+        <UpdateSiteName siteName={site.name} setMsg={setMsg} />
+        <UpdateSiteDomain siteDomain={site.domain} setMsg={setMsg} />
+        <UploadSiteIcon setMsg={setMsg} />
+      </div>
+    </section>
+  );
+};
+
 const Content: FC = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { site } = useSite();
@@ -126,62 +151,63 @@ const Content: FC = () => {
   return (
     <div className="grid md:grid-cols-2 gap-x-12">
       <div>
-        <h2>Basic information</h2>
-        <div className="flex flex-col gap-12">
-          <UpdateSiteName siteName={site.name} />
-          <UpdateSiteDomain siteDomain={site.domain} />
-          <UploadSiteIcon />
-        </div>
+        <UpdateSite site={site} />
         <hr className="md:hidden" />
       </div>
       <div>
-        <h2>Site ID</h2>
-        <p>Your site ID is</p>
-        <CopiableCode content={site.id} className="mb-6" />
-        <p>
-          You can use this to implement your own comment frontend based on the REST API provided by
-          ezkomment. <A href="https://google.com">See more in the documentation</A>.
-        </p>
+        <section>
+          <h2>Site ID</h2>
+          <p>Your site ID is</p>
+          <CopiableCode content={site.id} className="mb-6" />
+          <p>
+            You can use this to implement your own comment frontend based on the REST API provided
+            by ezkomment. <A href="https://google.com">See more in the documentation</A>.
+          </p>
+        </section>
         <hr />
-        <h2>Export all data</h2>
-        <p>
-          You can request all data related to this site to be exported. You can only perform this
-          action once a day.
-        </p>
-        <RightAligned>
-          <Button icon={DnsOutlinedIcon}>Request data</Button>
-        </RightAligned>
+        <section>
+          <h2>Export all data</h2>
+          <p>
+            You can request all data related to this site to be exported. You can only perform this
+            action once a day.
+          </p>
+          <RightAligned>
+            <Button icon={DnsOutlinedIcon}>Request data</Button>
+          </RightAligned>
+        </section>
         <hr />
-        <h2>Delete site</h2>
-        <p>
-          This is an <strong>irreversible</strong> action. All site data, including all comments and
-          pages, will be completely erased and there is no way to recover it. All embed and API
-          endpoints for the site will also stop working. Proceed with caution.
-        </p>
-        <RightAligned>
-          <Button
-            variant="danger"
-            icon={DangerousOutlinedIcon}
-            onClick={() => setShowDeleteModal(true)}
-          >
-            Delete this site
-          </Button>
-        </RightAligned>
-        <Modal isVisible={showDeleteModal} onOutsideClick={() => setShowDeleteModal(false)}>
-          <div className="p-6 max-w-lg">
-            <h2>You are attempting a dangerous action.</h2>
-            <p>
-              Deleting a site is <strong>irreversible</strong>, and we cannot do anything to recover
-              any data related to the site. Please think twice before proceeding.
-            </p>
-            <RightAligned className="gap-3">
-              <Button variant="tertiary" onClick={() => setShowDeleteModal(false)}>
-                Cancel
-              </Button>
-              <Button variant="danger">Delete</Button>
-            </RightAligned>
-          </div>
-        </Modal>
+        <section>
+          <h2>Delete site</h2>
+          <p>
+            This is an <strong>irreversible</strong> action. All site data, including all comments
+            and pages, will be completely erased and there is no way to recover it. All embed and
+            API endpoints for the site will also stop working. Proceed with caution.
+          </p>
+          <RightAligned>
+            <Button
+              variant="danger"
+              icon={DangerousOutlinedIcon}
+              onClick={() => setShowDeleteModal(true)}
+            >
+              Delete this site
+            </Button>
+          </RightAligned>
+          <Modal isVisible={showDeleteModal} onOutsideClick={() => setShowDeleteModal(false)}>
+            <div className="p-6 max-w-lg">
+              <h2>You are attempting a dangerous action.</h2>
+              <p>
+                Deleting a site is <strong>irreversible</strong>, and we cannot do anything to
+                recover any data related to the site. Please think twice before proceeding.
+              </p>
+              <RightAligned className="gap-3">
+                <Button variant="tertiary" onClick={() => setShowDeleteModal(false)}>
+                  Cancel
+                </Button>
+                <Button variant="danger">Delete</Button>
+              </RightAligned>
+            </div>
+          </Modal>
+        </section>
       </div>
     </div>
   );

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -79,7 +79,7 @@ const UpdateSiteName: FC<{ site: Site; setMsg: (msg: Msg) => void }> = ({ site, 
         options: { body: JSON.stringify({ name }) },
       });
       if (!success) throw UNABLE_TO_UPDATE_SITE;
-      router.replace(`/app/site/${name}/settings?switchingSiteName=1`);
+      router.replace(`/app/site/${name}/settings?loading=1`);
       const newUser = await getUser();
       setUser(newUser);
       mutate({ ...site, name });
@@ -226,7 +226,7 @@ const DeleteSite: FC<{ site: Site }> = ({ site }) => {
     try {
       const { success } = await internalFetcher({ url: `/api/sites/${site.id}`, method: "DELETE" });
       if (!success) throw UNABLE_TO_DELETE_SITE;
-      router.replace("/app/dashboard?waitingAuth=true");
+      router.replace("/app/dashboard?loading=1");
       const newUser = await getUser();
       setUser(newUser);
     } catch (err: any) {

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -1,5 +1,4 @@
 import { FC, useState } from "react";
-import useSWR from "swr";
 
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
@@ -7,7 +6,7 @@ import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
 
-import { internalSWRGenerator } from "~/client/lib/fetcher";
+import { useSite } from "~/client/hooks/site";
 
 import A from "~/client/components/anchor";
 import sitePages from "~/client/components/app/handleSite";
@@ -16,8 +15,6 @@ import CopiableCode from "~/client/components/copiableCode";
 import { InputDetachedLabel } from "~/client/components/forms/input";
 import Modal from "~/client/components/modal";
 import RightAligned from "~/client/components/utils/rightAligned";
-
-import { Site } from "~/types/server";
 
 const LoadingSection: FC = () => (
   <section>
@@ -53,11 +50,9 @@ const Loading: FC = () => (
   </div>
 );
 
-const Content: FC<{ siteId: string }> = ({ siteId }) => {
+const Content: FC = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const { data: site } = useSWR(`/api/sites/${siteId}`, internalSWRGenerator<Site | null>(), {
-    fallbackData: null,
-  });
+  const { site } = useSite();
   if (!site) return <Loading />;
   return (
     <div className="grid md:grid-cols-2 gap-x-12">

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -1,11 +1,12 @@
 import { FC, FormEventHandler, useState } from "react";
-import { SITE } from "~/misc/validate";
 
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
 import LabelOutlinedIcon from "@mui/icons-material/LabelOutlined";
 import WebOutlinedIcon from "@mui/icons-material/LanguageOutlined";
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
+
+import { SITE } from "~/misc/validate";
 
 import useAuth from "~/client/hooks/auth";
 import { useSite } from "~/client/hooks/site";

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -63,9 +63,32 @@ const Loading: FC = () => (
 );
 
 const UpdateSiteName: FC<{ site: Site; setMsg: (msg: Msg) => void }> = ({ site, setMsg }) => {
+  const { setLoading } = useAuth();
+  const { mutate } = useSite();
   const [name, setName] = useState(site.name);
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async event => {
+    event.preventDefault();
+    setLoading(true);
+    try {
+      const { success } = await internalFetcher({
+        url: `/api/sites/${site.id}`,
+        method: "PUT",
+        options: { body: JSON.stringify({ name }) },
+      });
+      if (!success) throw UNABLE_TO_UPDATE_SITE;
+      const { name: newName } = (await mutate({ ...site, name })) as Site;
+      setMsg({
+        type: "success",
+        message: <>Site name updated successfully. Redirecting to new URL&hellip;</>,
+      });
+      window.location.assign(`/app/site/${newName}/settings`);
+    } catch (err: any) {
+      setMsg({ type: "error", message: <AuthError err={err} /> });
+    }
+    setLoading(false);
+  };
   return (
-    <form className="flex flex-col gap-6">
+    <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
       <InputDetachedLabel
         label="Site name"
         icon={LabelOutlinedIcon}

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from "react";
+import { SITE } from "~/misc/validate";
 
 import DangerousOutlinedIcon from "@mui/icons-material/DangerousOutlined";
 import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
@@ -60,12 +61,13 @@ const UpdateSiteName: FC<{ siteName: string }> = ({ siteName }) => {
         icon={LabelOutlinedIcon}
         type="text"
         value={name}
+        isInvalid={!SITE.nameIsValid(name)}
         helpText="The site name helps identify your site in the dashboard and the URL."
         onUpdate={setName}
         required
       />
       <RightAligned>
-        <Button icon={SaveOutlinedIcon} disabled={name === "" || name === siteName}>
+        <Button icon={SaveOutlinedIcon} disabled={name === siteName || !SITE.nameIsValid(name)}>
           Save
         </Button>
       </RightAligned>
@@ -82,12 +84,16 @@ const UpdateSiteDomain: FC<{ siteDomain: string }> = ({ siteDomain }) => {
         icon={WebOutlinedIcon}
         type="text"
         value={domain}
+        isInvalid={!SITE.domainIsValid(domain)}
         helpText="The domain is where you want to host the comments. It can be any domain or subdomain. Other websites will not be allowed to host the comments."
         onUpdate={setDomain}
         required
       />
       <RightAligned>
-        <Button icon={SaveOutlinedIcon} disabled={domain === "" || domain === siteDomain}>
+        <Button
+          icon={SaveOutlinedIcon}
+          disabled={domain === siteDomain || !SITE.domainIsValid(domain)}
+        >
           Save
         </Button>
       </RightAligned>

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -280,15 +280,11 @@ const Content: FC = () => {
   );
 };
 
-const {
-  Page: SiteOverview,
-  getStaticPaths,
-  getStaticProps,
-} = sitePages({
+const SiteOverview = sitePages({
   title: siteName => `Settings | ${siteName}`,
   activeTab: "settings",
   Loading,
   Content,
 });
 
-export { SiteOverview as default, getStaticPaths, getStaticProps };
+export default SiteOverview;

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -62,11 +62,8 @@ const Loading: FC = () => (
   </div>
 );
 
-const UpdateSiteName: FC<{ siteName: string; setMsg: (msg: Msg) => void }> = ({
-  siteName,
-  setMsg,
-}) => {
-  const [name, setName] = useState(siteName);
+const UpdateSiteName: FC<{ site: Site; setMsg: (msg: Msg) => void }> = ({ site, setMsg }) => {
+  const [name, setName] = useState(site.name);
   return (
     <form className="flex flex-col gap-6">
       <InputDetachedLabel
@@ -80,7 +77,7 @@ const UpdateSiteName: FC<{ siteName: string; setMsg: (msg: Msg) => void }> = ({
         required
       />
       <RightAligned>
-        <Button icon={SaveOutlinedIcon} disabled={name === siteName || !SITE.nameIsValid(name)}>
+        <Button icon={SaveOutlinedIcon} disabled={name === site.name || !SITE.nameIsValid(name)}>
           Save
         </Button>
       </RightAligned>
@@ -164,6 +161,7 @@ const UploadSiteIcon: FC<{ site: Site; setMsg: (msg: Msg) => void }> = ({ site, 
       <IconUpload
         label="Site icon"
         helpText="This icon helps you identify this site over other sites you also have."
+        file={icon}
         onUpdate={setIcon}
       />
       <RightAligned>
@@ -182,7 +180,7 @@ const UpdateSite: FC<{ site: Site }> = ({ site }) => {
       <h2>Basic information</h2>
       {msg && <MsgBanner msg={msg} />}
       <div className="flex flex-col gap-12">
-        <UpdateSiteName siteName={site.name} setMsg={setMsg} />
+        <UpdateSiteName site={site} setMsg={setMsg} />
         <UpdateSiteDomain site={site} setMsg={setMsg} />
         <UploadSiteIcon site={site} setMsg={setMsg} />
       </div>

--- a/pages/app/site/[siteName]/settings.tsx
+++ b/pages/app/site/[siteName]/settings.tsx
@@ -12,6 +12,7 @@ import A from "~/client/components/anchor";
 import sitePages from "~/client/components/app/handleSite";
 import Button from "~/client/components/buttons";
 import CopiableCode from "~/client/components/copiableCode";
+import IconUpload from "~/client/components/forms/iconUpload";
 import { InputDetachedLabel } from "~/client/components/forms/input";
 import Modal from "~/client/components/modal";
 import RightAligned from "~/client/components/utils/rightAligned";
@@ -50,6 +51,68 @@ const Loading: FC = () => (
   </div>
 );
 
+const UpdateSiteName: FC<{ siteName: string }> = ({ siteName }) => {
+  const [name, setName] = useState(siteName);
+  return (
+    <form className="flex flex-col gap-6">
+      <InputDetachedLabel
+        label="Site name"
+        icon={LabelOutlinedIcon}
+        type="text"
+        value={name}
+        helpText="The site name helps identify your site in the dashboard and the URL."
+        onUpdate={setName}
+        required
+      />
+      <RightAligned>
+        <Button icon={SaveOutlinedIcon} disabled={name === "" || name === siteName}>
+          Save
+        </Button>
+      </RightAligned>
+    </form>
+  );
+};
+
+const UpdateSiteDomain: FC<{ siteDomain: string }> = ({ siteDomain }) => {
+  const [domain, setDomain] = useState(siteDomain);
+  return (
+    <form className="flex flex-col gap-6">
+      <InputDetachedLabel
+        label="Site domain"
+        icon={WebOutlinedIcon}
+        type="text"
+        value={domain}
+        helpText="The domain is where you want to host the comments. It can be any domain or subdomain. Other websites will not be allowed to host the comments."
+        onUpdate={setDomain}
+        required
+      />
+      <RightAligned>
+        <Button icon={SaveOutlinedIcon} disabled={domain === "" || domain === siteDomain}>
+          Save
+        </Button>
+      </RightAligned>
+    </form>
+  );
+};
+
+const UploadSiteIcon: FC = () => {
+  const [icon, setIcon] = useState<File | null>(null);
+  return (
+    <form className="flex flex-col gap-6">
+      <IconUpload
+        label="Site icon"
+        helpText="This icon helps you identify this site over other sites you also have."
+        onUpdate={setIcon}
+      />
+      <RightAligned>
+        <Button icon={SaveOutlinedIcon} disabled={!icon}>
+          Save
+        </Button>
+      </RightAligned>
+    </form>
+  );
+};
+
 const Content: FC = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { site } = useSite();
@@ -58,36 +121,14 @@ const Content: FC = () => {
     <div className="grid md:grid-cols-2 gap-x-12">
       <div>
         <h2>Basic information</h2>
-        <form className="flex flex-col gap-6">
-          <InputDetachedLabel
-            label="Site name"
-            icon={LabelOutlinedIcon}
-            type="text"
-            value={site.name}
-            helpText="The site name helps identify your site in the dashboard and the URL."
-            onUpdate={() => {}}
-            required
-          />
-          <InputDetachedLabel
-            label="Site domain"
-            icon={WebOutlinedIcon}
-            type="text"
-            value={site.domain}
-            helpText={
-              <>
-                The domain is where you want to host the comments. It can be any domain or
-                subdomain. Other websites will not be allowed to host the comments. Use an asterisk
-                (<code>*</code>) to allow all domains.
-              </>
-            }
-            onUpdate={() => {}}
-            required
-          />
-          <RightAligned>
-            <Button icon={SaveOutlinedIcon}>Save</Button>
-          </RightAligned>
-        </form>
-        <hr />
+        <div className="flex flex-col gap-12">
+          <UpdateSiteName siteName={site.name} />
+          <UpdateSiteDomain siteDomain={site.domain} />
+          <UploadSiteIcon />
+        </div>
+        <hr className="md:hidden" />
+      </div>
+      <div>
         <h2>Site ID</h2>
         <p>Your site ID is</p>
         <CopiableCode content={site.id} className="mb-6" />
@@ -95,9 +136,7 @@ const Content: FC = () => {
           You can use this to implement your own comment frontend based on the REST API provided by
           ezkomment. <A href="https://google.com">See more in the documentation</A>.
         </p>
-        <hr className="md:hidden" />
-      </div>
-      <div>
+        <hr />
         <h2>Export all data</h2>
         <p>
           You can request all data related to this site to be exported. You can only perform this

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -33,6 +33,7 @@ module.exports = {
   importOrder: [
     "^@mui/(.*)$",
     "^~/config/(.*)$",
+    "^~/misc/(.*)$",
     // Server import order
     "^~/server/(.*)$",
     // Client import order

--- a/sample/site.json
+++ b/sample/site.json
@@ -1,6 +1,6 @@
 {
   "id": "b09080dca06bea09c74d",
-  "name": "blog-app",
+  "name": "docs-app",
   "domain": "blog.mydomain.com",
   "iconURL": "/favicon.ico",
   "pageCount": 10,

--- a/server/utils/errors/handleFirestoreError.ts
+++ b/server/utils/errors/handleFirestoreError.ts
@@ -4,6 +4,8 @@ export function handleFirestoreError(err: unknown): never {
     if (err instanceof Error && !(err instanceof CustomApiError)) {
         const code: number = (err as any).code;
         if (code === 5) throw new CustomApiError(err, 404);
+        // Will change later, as code 6 may happen for different reason.
+        if (code === 6) throw new CustomApiError("Name has been taken", 409);
     }
     throw err;
 }

--- a/types/client/auth.type.ts
+++ b/types/client/auth.type.ts
@@ -1,7 +1,11 @@
-import { GithubAuthProvider, GoogleAuthProvider, User } from "firebase/auth";
+import { User as FirebaseUser, GithubAuthProvider, GoogleAuthProvider } from "firebase/auth";
 import { Dispatch, SetStateAction } from "react";
 
+import { Site } from "~/types/server";
+
 export type Provider = GithubAuthProvider | GoogleAuthProvider;
+
+export type User = FirebaseUser & { sites: Site[] };
 
 export type AppAuth = {
     user: User | null;

--- a/types/client/components.type.ts
+++ b/types/client/components.type.ts
@@ -86,6 +86,7 @@ export type IconAndLabelProps = IconAndLabel & {
 
 export type InputProps = (ComponentProps<"input"> & IconAndLabel) & {
     type: ComponentProps<"input">["type"]; // make `type` required.
+    isInvalid?: boolean;
     onUpdate?: (value: string) => void;
 };
 

--- a/types/client/components.type.ts
+++ b/types/client/components.type.ts
@@ -99,6 +99,12 @@ export type SelectProps = (ComponentProps<"select"> & IconAndLabel) & {
     onUpdate?: (value: string) => void;
 };
 
+export type IconUploaderProps = {
+    label: string;
+    helpText: ReactNode;
+    onUpdate?: (file: File | null) => void;
+};
+
 export type HomeButtonLinkProps = {
     href: string;
     className: string;

--- a/types/client/components.type.ts
+++ b/types/client/components.type.ts
@@ -102,6 +102,7 @@ export type SelectProps = (ComponentProps<"select"> & IconAndLabel) & {
 export type IconUploaderProps = {
     label: string;
     helpText: ReactNode;
+    file: File | null;
     onUpdate?: (file: File | null) => void;
 };
 

--- a/types/client/page.type.ts
+++ b/types/client/page.type.ts
@@ -35,6 +35,7 @@ export type CurrentPage =
 export type SitePagesOptions = {
     title: (siteName: string) => string;
     activeTab: NavbarItems["site"];
+    removePadding?: boolean;
     Loading: FC;
     Content: FC<{ siteId: string }>;
 };

--- a/types/client/page.type.ts
+++ b/types/client/page.type.ts
@@ -1,4 +1,7 @@
-import { FC } from "react";
+import { Dispatch, FC, SetStateAction } from "react";
+import { KeyedMutator } from "swr";
+
+import { Site } from "~/types/server";
 
 export type PageType = "overview" | "site" | "page" | "others";
 export type NavbarItems = {
@@ -37,5 +40,10 @@ export type SitePagesOptions = {
     activeTab: NavbarItems["site"];
     removePadding?: boolean;
     Loading: FC;
-    Content: FC<{ siteId: string }>;
+    Content: FC;
+};
+
+export type SiteContextProps = {
+    site: Site | undefined;
+    mutate: KeyedMutator<Site | undefined>;
 };

--- a/types/client/page.type.ts
+++ b/types/client/page.type.ts
@@ -1,3 +1,5 @@
+import { FC } from "react";
+
 export type PageType = "overview" | "site" | "page" | "others";
 export type NavbarItems = {
     overview: "dashboard" | "new" | "account";
@@ -29,3 +31,10 @@ export type CurrentPage =
           siteName?: never;
           pageId?: never;
       };
+
+export type SitePagesOptions = {
+    title: (siteName: string) => string;
+    activeTab: NavbarItems["site"];
+    Loading: FC;
+    Content: FC<{ siteId: string }>;
+};

--- a/types/client/utils.type.ts
+++ b/types/client/utils.type.ts
@@ -18,7 +18,7 @@ export type ModeContextType = {
     setMode: Dispatch<SetStateAction<Mode>>;
 };
 
-export type Breakpoint = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "unknown";
+export type Breakpoint = "xs" | "sm" | "md" | "lg" | "xl" | "unknown";
 export type BreakpointContextType = Breakpoint;
 
 export type BuildInfo = { hash: string; timestamp: number };

--- a/types/client/utils.type.ts
+++ b/types/client/utils.type.ts
@@ -58,3 +58,9 @@ export type ProjectLog = {
         remarks: string;
     }[];
 };
+
+export type FetchOptions = {
+    url: string;
+    method?: "GET" | "POST" | "PUT" | "DELETE";
+    options?: RequestInit;
+};

--- a/types/client/utils.type.ts
+++ b/types/client/utils.type.ts
@@ -1,12 +1,17 @@
 import { NextPage } from "next";
 import { AppProps } from "next/app";
+import { NextRouter } from "next/router";
 import { Dispatch, ReactElement, ReactNode, SetStateAction } from "react";
 
 import { OverridableComponent } from "@mui/material/OverridableComponent";
 import { SvgIconTypeMap } from "@mui/material/SvgIcon/SvgIcon";
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-    getLayout?: (page: ReactElement, pageProps?: AppPropsWithLayout["pageProps"]) => ReactNode;
+    getLayout?: (
+        page: ReactElement,
+        pageProps: AppPropsWithLayout["pageProps"],
+        router: NextRouter
+    ) => ReactNode;
 };
 export type AppPropsWithLayout<P = {}> = AppProps<P> & {
     Component: NextPageWithLayout;

--- a/types/client/utils.type.ts
+++ b/types/client/utils.type.ts
@@ -64,3 +64,8 @@ export type FetchOptions = {
     method?: "GET" | "POST" | "PUT" | "DELETE";
     options?: RequestInit;
 };
+
+export type ResponseMessage = {
+    type: "success" | "error";
+    message: ReactNode;
+} | null;

--- a/types/client/utils.type.ts
+++ b/types/client/utils.type.ts
@@ -61,8 +61,11 @@ export type ProjectLog = {
 
 export type FetchOptions = {
     url: string;
-    method?: "GET" | "POST" | "PUT" | "DELETE";
     options?: RequestInit;
+};
+
+export type FetchOptionsWithMethod = FetchOptions & {
+    method?: "GET" | "POST" | "PUT" | "DELETE";
 };
 
 export type ResponseMessage = {


### PR DESCRIPTION
This is a *lot* more work than I ever expected it to be. But it's now completed. Will look at it again tomorrow.

## Create

* [x] Can create sites
* [x] Redirected to site dashboard after creation
* [x] Newly created site listed on user dashboard
* [x] Navbar works
* [x] Router works

## Read

* [x] Can read site info from user dashboard
* [x] Can read site info from site dashboard
* [x] Also run `GET /api/sites/:siteId` (it is not necessary at the moment since the info returned is literally a subset of `GET /api/users/:uid/sites`, but it will be necessary when #125 is fixed).
* [x] Site info is propagated as a context to not fetch too often

## Update

* [x] Can update site name
* [x] Good UX after updating site name (and changing the page URL)
* [x] Can update site domain
* [x] Can update site photo (although a bit bumpy right now, but we can't fix it unless we change the URL every time, see #127)
* [x] Both dashboard is also updated automatically without any loading pages

## Delete

* [x] Can delete sites
* [x] Redirect to dashboard after deleting, dashboard should be updated

## Enhancements

* [x] All site pages are now static: no `getServerSideProps` so they can be prefetched and router is fast