### PR TITLE
Fix #137 and #139

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,3 +22,16 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
+
+  # Need to install firebase emulator, and how can we load env variable for testing?
+
+  # test-backend:
+  #   runs-on: ubuntu-lastest
+  #   steps:
+  #     - uses: action/checkout@v2
+  #     - uses: action/setup-node@v2
+  #       with:
+  #         node-version: "16"
+  #         cache: "yarn"
+  #     - run: yarn
+  #     - run: yarn emulate:test:server:ci

--- a/__tests__/server/comments.test.ts
+++ b/__tests__/server/comments.test.ts
@@ -4,16 +4,17 @@ import * as TestUtils from "~/server/utils/testUtils";
 import { nonExistingCommentId, nonExistingPageId } from "~/sample/server/nonExistingIds.json";
 
 describe("Test comment utils", () => {
+    const uid = TestUtils.randomUUID();
     const siteId = TestUtils.randomUUID();
     const pageId = TestUtils.randomUUID();
     const [commentId, ...restCommentIds] = Array.from({ length: 5 }, TestUtils.randomUUID);
     const mainSite = TestUtils.createTestSite({
-        uid: "_",
+        uid,
         id: siteId,
         pageCount: 1,
         totalCommentCount: 5,
     });
-    const mainPage = TestUtils.createTestPage({ siteId, id: pageId, totalCommentCount: 5 });
+    const mainPage = TestUtils.createTestPage({ uid, siteId, id: pageId, totalCommentCount: 5 });
     const mainComment = TestUtils.createTestComment({ siteId, pageId, id: commentId });
 
     beforeAll(async () => {

--- a/__tests__/server/pages.test.ts
+++ b/__tests__/server/pages.test.ts
@@ -8,14 +8,14 @@ describe("Test page utils", () => {
     const uid = TestUtils.randomUUID();
     const siteId = TestUtils.randomUUID();
     const [pageId1, pageId2, ...restPageIds] = Array.from({ length: 5 }, TestUtils.randomUUID);
-    const pageName = "Eternal Knowledge";
+    const pageTitle = "Eternal Knowledge";
     const mainSite = TestUtils.createTestSite({
         uid,
         id: siteId,
         pageCount: 5,
         totalCommentCount: 5,
     });
-    const mainPage = TestUtils.createTestPage({ siteId, id: pageId1, name: pageName });
+    const mainPage = TestUtils.createTestPage({ uid, siteId, id: pageId1, title: pageTitle });
 
     const commentIds = Array.from({ length: 5 }, TestUtils.randomUUID);
 
@@ -24,8 +24,8 @@ describe("Test page utils", () => {
             sites: [mainSite], // do not forget to create the site
             pages: [
                 mainPage,
-                TestUtils.createTestPage({ siteId, id: pageId2, totalCommentCount: 5 }),
-                ...restPageIds.map(id => TestUtils.createTestPage({ siteId, id })),
+                TestUtils.createTestPage({ uid, siteId, id: pageId2, totalCommentCount: 5 }),
+                ...restPageIds.map(id => TestUtils.createTestPage({ uid, siteId, id })),
             ],
             comments: commentIds.map(id =>
                 TestUtils.createTestComment({ siteId, pageId: pageId2, id })
@@ -36,7 +36,7 @@ describe("Test page utils", () => {
     it(`Should be able to get page's information`, async () => {
         await expect(PageUtils.getPageById(uid, pageId1)).resolves.toMatchObject({
             id: pageId1,
-            name: pageName,
+            title: pageTitle,
         });
     });
 
@@ -46,23 +46,12 @@ describe("Test page utils", () => {
         });
     });
 
-    it(`Should fail when trying to create a new page with duplicated name`, async () => {
-        await expect(
-            PageUtils.createPage(uid, {
-                url: `${mainSite.domain}/Scarlet%2FSerenade`,
-                autoApprove: false,
-                name: pageName,
-                siteId,
-            })
-        ).rejects.toMatchObject({ code: 409 });
-    });
-
     it(`Should fail when trying to create a new page with a non-existing site`, async () => {
         await expect(
             PageUtils.createPage(uid, {
                 url: "https://en.touhouwiki.net/wiki/Flandre_Scarlet",
                 autoApprove: false,
-                name: "Necrofantasia",
+                title: "Necrofantasia",
                 siteId: nonExistingSiteId,
             })
         ).rejects.toMatchObject({ code: 404 });
@@ -73,7 +62,7 @@ describe("Test page utils", () => {
             PageUtils.createPage(uid, {
                 url: "https://EoSD.com/6",
                 autoApprove: false,
-                name: "Scarlet Devil",
+                title: "Scarlet Devil",
                 siteId,
             })
         ).rejects.toMatchObject({ code: 409 });
@@ -83,14 +72,6 @@ describe("Test page utils", () => {
         await expect(
             PageUtils.updatePageById(uid, nonExistingPageId, { autoApprove: false })
         ).rejects.toMatchObject({ code: 404 });
-    });
-
-    it(`Should fail when trying to update a page with duplicated name`, async () => {
-        await expect(
-            PageUtils.updatePageById(uid, pageId2, { name: pageName })
-        ).rejects.toMatchObject({
-            code: 409,
-        });
     });
 
     it(`Should fail when trying to delete a non-existing page`, async () => {

--- a/__tests__/server/pages.test.ts
+++ b/__tests__/server/pages.test.ts
@@ -83,9 +83,6 @@ describe("Test page utils", () => {
     it(`Should delete page correctly`, async () => {
         await PageUtils.deletePageById(uid, pageId1);
         await Promise.all([
-            expect(PageUtils.listSiteBasicPagesById(siteId)).resolves.toEqual(
-                expect.not.arrayContaining([pageId1])
-            ),
             expect(PageUtils.listSitePagesById(siteId)).resolves.toEqual(
                 expect.not.arrayContaining([mainPage])
             ),
@@ -95,7 +92,6 @@ describe("Test page utils", () => {
     it(`Should be able to delete ALL pages of a site`, async () => {
         await PageUtils.deleteSitePagesById(siteId);
         await Promise.all([
-            expect(PageUtils.listSiteBasicPagesById(siteId)).resolves.toHaveLength(0),
             expect(PageUtils.listSitePagesById(siteId)).resolves.toHaveLength(0),
             expect(CommentUtils.listPageCommentsById(pageId2)).resolves.toHaveLength(0),
         ]);

--- a/__tests__/server/pages.test.ts
+++ b/__tests__/server/pages.test.ts
@@ -5,11 +5,12 @@ import * as TestUtils from "~/server/utils/testUtils";
 import { nonExistingPageId, nonExistingSiteId } from "~/sample/server/nonExistingIds.json";
 
 describe("Test page utils", () => {
+    const uid = TestUtils.randomUUID();
     const siteId = TestUtils.randomUUID();
     const [pageId1, pageId2, ...restPageIds] = Array.from({ length: 5 }, TestUtils.randomUUID);
     const pageName = "Eternal Knowledge";
     const mainSite = TestUtils.createTestSite({
-        uid: "_",
+        uid,
         id: siteId,
         pageCount: 5,
         totalCommentCount: 5,
@@ -33,19 +34,21 @@ describe("Test page utils", () => {
     });
 
     it(`Should be able to get page's information`, async () => {
-        await expect(PageUtils.getPageById(pageId1)).resolves.toMatchObject({
+        await expect(PageUtils.getPageById(uid, pageId1)).resolves.toMatchObject({
             id: pageId1,
             name: pageName,
         });
     });
 
     it(`Should fail when trying to get a non-existing page`, async () => {
-        await expect(PageUtils.getPageById(nonExistingPageId)).rejects.toMatchObject({ code: 404 });
+        await expect(PageUtils.getPageById(uid, nonExistingPageId)).rejects.toMatchObject({
+            code: 404,
+        });
     });
 
     it(`Should fail when trying to create a new page with duplicated name`, async () => {
         await expect(
-            PageUtils.createPage({
+            PageUtils.createPage(uid, {
                 url: `${mainSite.domain}/Scarlet%2FSerenade`,
                 autoApprove: false,
                 name: pageName,
@@ -56,7 +59,7 @@ describe("Test page utils", () => {
 
     it(`Should fail when trying to create a new page with a non-existing site`, async () => {
         await expect(
-            PageUtils.createPage({
+            PageUtils.createPage(uid, {
                 url: "https://en.touhouwiki.net/wiki/Flandre_Scarlet",
                 autoApprove: false,
                 name: "Necrofantasia",
@@ -67,7 +70,7 @@ describe("Test page utils", () => {
 
     it(`Should fail when trying to create a new page with unmatched url`, async () => {
         await expect(
-            PageUtils.createPage({
+            PageUtils.createPage(uid, {
                 url: "https://EoSD.com/6",
                 autoApprove: false,
                 name: "Scarlet Devil",
@@ -78,24 +81,26 @@ describe("Test page utils", () => {
 
     it(`Should fail when trying to update a non-exsting page`, async () => {
         await expect(
-            PageUtils.updatePageById(nonExistingPageId, { autoApprove: false })
+            PageUtils.updatePageById(uid, nonExistingPageId, { autoApprove: false })
         ).rejects.toMatchObject({ code: 404 });
     });
 
     it(`Should fail when trying to update a page with duplicated name`, async () => {
-        await expect(PageUtils.updatePageById(pageId2, { name: pageName })).rejects.toMatchObject({
+        await expect(
+            PageUtils.updatePageById(uid, pageId2, { name: pageName })
+        ).rejects.toMatchObject({
             code: 409,
         });
     });
 
     it(`Should fail when trying to delete a non-existing page`, async () => {
-        await expect(PageUtils.deletePageById(nonExistingPageId)).rejects.toMatchObject({
+        await expect(PageUtils.deletePageById(uid, nonExistingPageId)).rejects.toMatchObject({
             code: 404,
         });
     });
 
     it(`Should delete page correctly`, async () => {
-        await PageUtils.deletePageById(pageId1);
+        await PageUtils.deletePageById(uid, pageId1);
         await Promise.all([
             expect(PageUtils.listSiteBasicPagesById(siteId)).resolves.toEqual(
                 expect.not.arrayContaining([pageId1])

--- a/__tests__/server/sites.test.ts
+++ b/__tests__/server/sites.test.ts
@@ -100,7 +100,6 @@ describe("Test site utils", () => {
             expect(SiteUtils.listUserBasicSitesById(uid)).resolves.toHaveLength(0),
             expect(SiteUtils.listUserSitesById(uid)).resolves.toHaveLength(0),
             expect(PageUtils.listSitePagesById(siteId2)).resolves.toHaveLength(0),
-            expect(PageUtils.listSiteBasicPagesById(siteId2)).resolves.toHaveLength(0),
             expect(CommentUtils.listPageCommentsById(pageId)).resolves.toHaveLength(0),
         ]);
     });

--- a/__tests__/server/sites.test.ts
+++ b/__tests__/server/sites.test.ts
@@ -27,7 +27,7 @@ describe("Test site utils", () => {
                 TestUtils.createTestSite({ uid, id: siteId2, pageCount: 5, totalCommentCount: 5 }),
                 ...restSiteIds.map(id => TestUtils.createTestSite({ uid, id })),
             ],
-            pages: pageIds.map(id => TestUtils.createTestPage({ siteId: siteId2, id })),
+            pages: pageIds.map(id => TestUtils.createTestPage({ uid, siteId: siteId2, id })),
             comments: commentIds.map(id =>
                 TestUtils.createTestComment({ siteId: siteId2, pageId, id })
             ),

--- a/__tests__/server/sites.test.ts
+++ b/__tests__/server/sites.test.ts
@@ -35,20 +35,21 @@ describe("Test site utils", () => {
     });
 
     it(`Should be able to get site's information`, async () => {
-        await expect(SiteUtils.getSiteById(siteId1)).resolves.toMatchObject({
+        await expect(SiteUtils.getSiteById(uid, siteId1)).resolves.toMatchObject({
             id: siteId1,
             name: siteName,
         });
     });
 
     it(`Should fail when trying to get a non-existing site`, async () => {
-        await expect(SiteUtils.getSiteById(nonExistingSiteId)).rejects.toMatchObject({ code: 404 });
+        await expect(SiteUtils.getSiteById(uid, nonExistingSiteId)).rejects.toMatchObject({
+            code: 404,
+        });
     });
 
     it(`Should fail when trying to create a new site with duplicated name`, async () => {
         await expect(
-            SiteUtils.createSite({
-                uid,
+            SiteUtils.createSite(uid, {
                 name: siteName,
                 domain: "https://en.touhouwiki.net/wiki/Yukari_Yakumo",
                 iconURL: null,
@@ -57,25 +58,27 @@ describe("Test site utils", () => {
     });
 
     it(`Should fail when trying to update a site with duplicated name`, async () => {
-        await expect(SiteUtils.updateSiteById(siteId2, { name: siteName })).rejects.toMatchObject({
+        await expect(
+            SiteUtils.updateSiteById(uid, siteId2, { name: siteName })
+        ).rejects.toMatchObject({
             code: 409,
         });
     });
 
     it(`Should fail when trying to update a non-existing site`, async () => {
         await expect(
-            SiteUtils.updateSiteById(nonExistingSiteId, { name: siteName })
+            SiteUtils.updateSiteById(uid, nonExistingSiteId, { name: siteName })
         ).rejects.toMatchObject({ code: 404 });
     });
 
     it(`Should fail when trying to delete a non-exisiting site`, async () => {
-        await expect(SiteUtils.deleteSiteById(nonExistingSiteId)).rejects.toMatchObject({
+        await expect(SiteUtils.deleteSiteById(uid, nonExistingSiteId)).rejects.toMatchObject({
             code: 404,
         });
     });
 
     it(`Should delete site correctly`, async () => {
-        await SiteUtils.deleteSiteById(siteId1);
+        await SiteUtils.deleteSiteById(uid, siteId1);
         await Promise.all([
             expect(SiteUtils.listUserBasicSitesById(uid)).resolves.toEqual(
                 expect.not.arrayContaining([siteId1])

--- a/pages/api/pages/[pageId].ts
+++ b/pages/api/pages/[pageId].ts
@@ -1,11 +1,13 @@
 import { deletePage, getPage, updatePage } from "~/server/handlers/pageHandlers";
-import { authenticateWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { sanitizeUpdatePageRequest } from "~/server/middlewares/sanitizeRequests/pages";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-const handler = ncRouter()
-    .get(authenticateWithJWT, getPage)
-    .put(sanitizeUpdatePageRequest, authenticateWithJWT, updatePage)
-    .delete(authenticateWithJWT, deletePage);
+import { AuthenticatedApiRequest } from "~/types/server/nextApi.type";
+
+const handler = ncRouter<AuthenticatedApiRequest>()
+    .get(attachIdTokenWithJWT, getPage)
+    .put(sanitizeUpdatePageRequest, attachIdTokenWithJWT, updatePage)
+    .delete(attachIdTokenWithJWT, deletePage);
 
 export default handler;

--- a/pages/api/pages/[pageId]/comments.ts
+++ b/pages/api/pages/[pageId]/comments.ts
@@ -1,6 +1,4 @@
-import { createComment } from "~/server/handlers/commentHandlers";
 import { listPageComments } from "~/server/handlers/pageHandlers";
-import { sanitizeCreateCommentRequest } from "~/server/middlewares/sanitizeRequests/comments";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
 const handler = ncRouter().get(listPageComments);

--- a/pages/api/pages/index.ts
+++ b/pages/api/pages/index.ts
@@ -1,8 +1,14 @@
 import { createPage } from "~/server/handlers/pageHandlers";
-import { authenticateWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { sanitizeCreatePageRequest } from "~/server/middlewares/sanitizeRequests/pages";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-const handler = ncRouter().post(sanitizeCreatePageRequest, authenticateWithJWT, createPage);
+import { AuthenticatedApiRequest } from "~/types/server/nextApi.type";
+
+const handler = ncRouter<AuthenticatedApiRequest>().post(
+    sanitizeCreatePageRequest,
+    attachIdTokenWithJWT,
+    createPage
+);
 
 export default handler;

--- a/pages/api/sites/[siteId].ts
+++ b/pages/api/sites/[siteId].ts
@@ -1,11 +1,13 @@
 import { deleteSite, getSite, updateSite } from "~/server/handlers/siteHandlers";
-import { authenticateWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { sanitizeUpdateSiteRequest } from "~/server/middlewares/sanitizeRequests/sites";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-const handler = ncRouter()
-    .get(authenticateWithJWT, getSite)
-    .put(sanitizeUpdateSiteRequest, authenticateWithJWT, updateSite)
-    .delete(authenticateWithJWT, deleteSite);
+import { AuthenticatedApiRequest } from "~/types/server/nextApi.type";
+
+const handler = ncRouter<AuthenticatedApiRequest>()
+    .get(attachIdTokenWithJWT, getSite)
+    .put(sanitizeUpdateSiteRequest, attachIdTokenWithJWT, updateSite)
+    .delete(attachIdTokenWithJWT, deleteSite);
 
 export default handler;

--- a/pages/api/sites/[siteId]/icon.ts
+++ b/pages/api/sites/[siteId]/icon.ts
@@ -1,11 +1,11 @@
 import { PageConfig } from "next";
 
 import { uploadSiteIcon } from "~/server/handlers/imageHandlers";
-import { authenticateWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { parseSiteIcon } from "~/server/middlewares/parseForms";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-import { ApiRequestWithFormData } from "~/types/server/nextApi.type";
+import { AuthenticatedApiRequestWithFormData } from "~/types/server/nextApi.type";
 
 export const config: PageConfig = {
     api: {
@@ -13,8 +13,8 @@ export const config: PageConfig = {
     },
 };
 
-const handler = ncRouter<ApiRequestWithFormData>().put(
-    authenticateWithJWT,
+const handler = ncRouter<AuthenticatedApiRequestWithFormData>().put(
+    attachIdTokenWithJWT,
     parseSiteIcon,
     uploadSiteIcon
 );

--- a/pages/api/sites/[siteId]/pages.ts
+++ b/pages/api/sites/[siteId]/pages.ts
@@ -1,7 +1,9 @@
 import { listSitePages } from "~/server/handlers/siteHandlers";
-import { authenticateWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-const handler = ncRouter().get(authenticateWithJWT, listSitePages);
+import { AuthenticatedApiRequest } from "~/types/server/nextApi.type";
+
+const handler = ncRouter<AuthenticatedApiRequest>().get(attachIdTokenWithJWT, listSitePages);
 
 export default handler;

--- a/pages/api/sites/index.ts
+++ b/pages/api/sites/index.ts
@@ -1,8 +1,14 @@
 import { createSite } from "~/server/handlers/siteHandlers";
-import { authenticateBodyUidWithJWT } from "~/server/middlewares/authenticateRequests";
+import { attachIdTokenWithJWT } from "~/server/middlewares/authenticateRequests";
 import { sanitizeCreateSiteRequest } from "~/server/middlewares/sanitizeRequests/sites";
 import { ncRouter } from "~/server/utils/nextHandlerUtils";
 
-const handler = ncRouter().post(sanitizeCreateSiteRequest, authenticateBodyUidWithJWT, createSite);
+import { AuthenticatedApiRequest } from "~/types/server/nextApi.type";
+
+const handler = ncRouter<AuthenticatedApiRequest>().post(
+    sanitizeCreateSiteRequest,
+    attachIdTokenWithJWT,
+    createSite
+);
 
 export default handler;

--- a/server/handlers/imageHandlers.ts
+++ b/server/handlers/imageHandlers.ts
@@ -3,7 +3,11 @@ import { updateSiteById } from "~/server/utils/crud/siteUtils";
 import { updateUserById } from "~/server/utils/crud/userUtils";
 import { extractFirstQueryValue } from "~/server/utils/nextHandlerUtils";
 
-import { ApiRequestWithFormData, ApiResponse } from "~/types/server/nextApi.type";
+import {
+    ApiRequestWithFormData,
+    ApiResponse,
+    AuthenticatedApiRequestWithFormData,
+} from "~/types/server/nextApi.type";
 
 export async function uploadUserPhoto(req: ApiRequestWithFormData, res: ApiResponse) {
     const { uid } = extractFirstQueryValue(req);
@@ -17,11 +21,12 @@ export async function uploadUserPhoto(req: ApiRequestWithFormData, res: ApiRespo
     });
 }
 
-export async function uploadSiteIcon(req: ApiRequestWithFormData, res: ApiResponse) {
+export async function uploadSiteIcon(req: AuthenticatedApiRequestWithFormData, res: ApiResponse) {
+    const { uid } = req.user;
     const { siteId } = extractFirstQueryValue(req);
     const imgName = `sites/${siteId}`;
     const iconURL = getImagePublicUrl(imgName);
-    await updateSiteById(siteId, { iconURL });
+    await updateSiteById(uid, siteId, { iconURL });
     await uploadImage(imgName, req.file);
     res.status(201).json({
         message: "Uploaded site's icon",

--- a/server/handlers/pageHandlers.ts
+++ b/server/handlers/pageHandlers.ts
@@ -1,40 +1,41 @@
-import { NextApiRequest } from "next";
-
 import * as PageUtils from "~/server/utils/crud/pageUtils";
 import { deletePageCommentsById, listPageCommentsById } from "~/server/utils/crud/commentUtils";
 import { extractFirstQueryValue } from "~/server/utils/nextHandlerUtils";
 
 import { CreatePageBodyParams, UpdatePageBodyParams } from "~/types/server";
-import { ApiResponse } from "~/types/server/nextApi.type";
+import { ApiResponse, AuthenticatedApiRequest } from "~/types/server/nextApi.type";
 
-export async function getPage(req: NextApiRequest, res: ApiResponse) {
+export async function getPage(req: AuthenticatedApiRequest, res: ApiResponse) {
     const { pageId } = extractFirstQueryValue(req);
     const data = await PageUtils.getPageById(pageId);
     const comments = await listPageCommentsById(pageId);
     res.status(200).json({ message: "Got page information", data: { ...data, comments } });
 }
 
-export async function createPage(req: NextApiRequest, res: ApiResponse) {
+export async function createPage(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const data: CreatePageBodyParams = req.body;
-    const result = await PageUtils.createPage(data);
+    const result = await PageUtils.createPage(uid, data);
     res.status(201).json({ message: "Created new page", data: result });
 }
 
-export async function updatePage(req: NextApiRequest, res: ApiResponse) {
+export async function updatePage(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { pageId } = extractFirstQueryValue(req);
     const data: UpdatePageBodyParams = req.body;
-    await PageUtils.updatePageById(pageId, data);
+    await PageUtils.updatePageById(uid, pageId, data);
     res.status(200).json({ message: "Updated page" });
 }
 
-export async function deletePage(req: NextApiRequest, res: ApiResponse) {
+export async function deletePage(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { pageId } = extractFirstQueryValue(req);
-    await PageUtils.deletePageById(pageId);
+    await PageUtils.deletePageById(uid, pageId);
     await deletePageCommentsById(pageId);
     res.status(200).json({ message: "Deleted page" });
 }
 
-export async function listPageComments(req: NextApiRequest, res: ApiResponse) {
+export async function listPageComments(req: AuthenticatedApiRequest, res: ApiResponse) {
     const { pageId } = extractFirstQueryValue(req);
     const data = await listPageCommentsById(pageId);
     res.status(200).json({ message: "Listed all comments", data });

--- a/server/handlers/pageHandlers.ts
+++ b/server/handlers/pageHandlers.ts
@@ -6,8 +6,9 @@ import { CreatePageBodyParams, UpdatePageBodyParams } from "~/types/server";
 import { ApiResponse, AuthenticatedApiRequest } from "~/types/server/nextApi.type";
 
 export async function getPage(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { pageId } = extractFirstQueryValue(req);
-    const data = await PageUtils.getPageById(pageId);
+    const data = await PageUtils.getPageById(uid, pageId);
     const comments = await listPageCommentsById(pageId);
     res.status(200).json({ message: "Got page information", data: { ...data, comments } });
 }

--- a/server/handlers/siteHandlers.ts
+++ b/server/handlers/siteHandlers.ts
@@ -7,8 +7,9 @@ import { CreateSiteBodyParams, SiteStatistics, UpdateSiteBodyParams } from "~/ty
 import { ApiResponse, AuthenticatedApiRequest } from "~/types/server/nextApi.type";
 
 export async function getSite(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { siteId } = extractFirstQueryValue(req);
-    const data = await SiteUtils.getSiteById(siteId);
+    const data = await SiteUtils.getSiteById(uid, siteId);
 
     /**
      * Get all information about pages here.

--- a/server/handlers/siteHandlers.ts
+++ b/server/handlers/siteHandlers.ts
@@ -1,16 +1,15 @@
-import { NextApiRequest } from "next";
-
 import * as SiteUtils from "~/server/utils/crud/siteUtils";
 import { deleteSiteIconById } from "~/server/utils/crud/imageUtils";
 import { deleteSitePagesById, listSitePagesById } from "~/server/utils/crud/pageUtils";
 import { extractFirstQueryValue } from "~/server/utils/nextHandlerUtils";
 
 import { CreateSiteBodyParams, SiteStatistics, UpdateSiteBodyParams } from "~/types/server";
-import { ApiResponse } from "~/types/server/nextApi.type";
+import { ApiResponse, AuthenticatedApiRequest } from "~/types/server/nextApi.type";
 
-export async function getSite(req: NextApiRequest, res: ApiResponse) {
+export async function getSite(req: AuthenticatedApiRequest, res: ApiResponse) {
     const { siteId } = extractFirstQueryValue(req);
     const data = await SiteUtils.getSiteById(siteId);
+
     /**
      * Get all information about pages here.
      */
@@ -30,22 +29,25 @@ export async function getSite(req: NextApiRequest, res: ApiResponse) {
     });
 }
 
-export async function createSite(req: NextApiRequest, res: ApiResponse) {
+export async function createSite(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const data: CreateSiteBodyParams = req.body;
-    const result = await SiteUtils.createSite(data);
+    const result = await SiteUtils.createSite(uid, data);
     res.status(201).json({ message: "Created site", data: result });
 }
 
-export async function updateSite(req: NextApiRequest, res: ApiResponse) {
+export async function updateSite(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { siteId } = extractFirstQueryValue(req);
     const data: UpdateSiteBodyParams = req.body;
-    await SiteUtils.updateSiteById(siteId, data);
+    await SiteUtils.updateSiteById(uid, siteId, data);
     res.status(200).json({ message: "Updated site" });
 }
 
-export async function deleteSite(req: NextApiRequest, res: ApiResponse) {
+export async function deleteSite(req: AuthenticatedApiRequest, res: ApiResponse) {
+    const { uid } = req.user;
     const { siteId } = extractFirstQueryValue(req);
-    await SiteUtils.deleteSiteById(siteId);
+    await SiteUtils.deleteSiteById(uid, siteId);
     await Promise.all([
         deleteSiteIconById(siteId), // delete icon
         deleteSitePagesById(siteId), // delete ALL pages
@@ -57,7 +59,7 @@ export async function deleteSite(req: NextApiRequest, res: ApiResponse) {
 // Interact with pages //
 /////////////////////////
 
-export async function listSitePages(req: NextApiRequest, res: ApiResponse) {
+export async function listSitePages(req: AuthenticatedApiRequest, res: ApiResponse) {
     const { siteId } = extractFirstQueryValue(req);
     const data = await listSitePagesById(siteId);
     res.status(200).json({ message: "Listed all pages", data });

--- a/server/middlewares/authenticateRequests.ts
+++ b/server/middlewares/authenticateRequests.ts
@@ -2,7 +2,7 @@ import { verifyJWT, verifySessionCookie } from "~/server/utils/authUtils";
 import CustomApiError from "~/server/utils/errors/customApiError";
 import { extractFirstQueryValue } from "~/server/utils/nextHandlerUtils";
 
-import { ApiMiddleware } from "~/types/server/nextApi.type";
+import { ApiMiddleware, AuthenticatedApiRequest } from "~/types/server/nextApi.type";
 
 /**
  * Middleware that checks whether the current user's uid and the targeted document's uid match.
@@ -47,5 +47,10 @@ export const authenticateWithJWT: ApiMiddleware = async (req, _, next) => {
 export const validateSessionCookie: ApiMiddleware = async (req, res, next) => {
     const sessionCookie = req.cookies.session;
     await verifySessionCookie(sessionCookie);
+    next();
+};
+
+export const attachUidWithJWT: ApiMiddleware<AuthenticatedApiRequest> = async (req, _, next) => {
+    req.user = await verifyJWT(req.headers.authorization);
     next();
 };

--- a/server/middlewares/authenticateRequests.ts
+++ b/server/middlewares/authenticateRequests.ts
@@ -44,13 +44,17 @@ export const authenticateWithJWT: ApiMiddleware = async (req, _, next) => {
     next();
 };
 
-export const validateSessionCookie: ApiMiddleware = async (req, res, next) => {
+export const validateSessionCookie: ApiMiddleware = async (req, _, next) => {
     const sessionCookie = req.cookies.session;
     await verifySessionCookie(sessionCookie);
     next();
 };
 
-export const attachUidWithJWT: ApiMiddleware<AuthenticatedApiRequest> = async (req, _, next) => {
+export const attachIdTokenWithJWT: ApiMiddleware<AuthenticatedApiRequest> = async (
+    req,
+    _,
+    next
+) => {
     req.user = await verifyJWT(req.headers.authorization);
     next();
 };

--- a/server/middlewares/authenticateRequests.ts
+++ b/server/middlewares/authenticateRequests.ts
@@ -32,29 +32,15 @@ export const authenticateBodyUidWithJWT: ApiMiddleware = async (req, _, next) =>
     next();
 };
 
-/**
- * For some endpoints, decode the token is good enough.
- */
-export const authenticateWithJWT: ApiMiddleware = async (req, _, next) => {
-    if (process.env.NODE_ENV === "development") {
-        next();
-        return;
-    }
-    await verifyJWT(req.headers.authorization);
-    next();
-};
-
 export const validateSessionCookie: ApiMiddleware = async (req, _, next) => {
     const sessionCookie = req.cookies.session;
     await verifySessionCookie(sessionCookie);
     next();
 };
 
-export const attachIdTokenWithJWT: ApiMiddleware<AuthenticatedApiRequest> = async (
-    req,
-    _,
-    next
-) => {
+type AuthenticatedApiMiddleware = ApiMiddleware<AuthenticatedApiRequest>;
+
+export const attachIdTokenWithJWT: AuthenticatedApiMiddleware = async (req, _, next) => {
     req.user = await verifyJWT(req.headers.authorization);
     next();
 };

--- a/server/middlewares/sanitizeRequests/pages.ts
+++ b/server/middlewares/sanitizeRequests/pages.ts
@@ -7,9 +7,9 @@ import { CreatePageBodyParams, RawBody, UpdatePageBodyParams } from "~/types/ser
 import { ApiMiddleware } from "~/types/server/nextApi.type";
 
 export const sanitizeCreatePageRequest: ApiMiddleware = (req, _, next) => {
-    const { name, url, autoApprove, siteId }: RawBody<CreatePageBodyParams> = req.body;
-    if (typeof name !== "string" || validator.isEmpty(name)) {
-        throw new CustomApiError("'name' must be a non-empty string");
+    const { title, url, autoApprove, siteId }: RawBody<CreatePageBodyParams> = req.body;
+    if (typeof title !== "string" || validator.isEmpty(title)) {
+        throw new CustomApiError("'title' must be a non-empty string");
     }
     if (typeof url !== "string" || !validator.isURL(url)) {
         throw new CustomApiError("'url' is invalid");
@@ -28,9 +28,9 @@ export const sanitizeCreatePageRequest: ApiMiddleware = (req, _, next) => {
 };
 
 export const sanitizeUpdatePageRequest: ApiMiddleware = (req, _, next) => {
-    const { name, url, autoApprove }: RawBody<UpdatePageBodyParams> = req.body;
-    if (name !== undefined && (typeof name !== "string" || validator.isEmpty(name))) {
-        throw new CustomApiError("'name' must be a non-empty string");
+    const { title, url, autoApprove }: RawBody<UpdatePageBodyParams> = req.body;
+    if (title !== undefined && (typeof title !== "string" || validator.isEmpty(title))) {
+        throw new CustomApiError("'title' must be a non-empty string");
     }
     if (url !== undefined && (typeof url !== "string" || !validator.isURL(url))) {
         throw new CustomApiError("'url' is invalid");

--- a/server/middlewares/sanitizeRequests/sites.ts
+++ b/server/middlewares/sanitizeRequests/sites.ts
@@ -7,27 +7,17 @@ import { CreateSiteBodyParams, RawBody, UpdateSiteBodyParams } from "~/types/ser
 import { ApiMiddleware } from "~/types/server/nextApi.type";
 
 export const sanitizeCreateSiteRequest: ApiMiddleware = (req, _, next) => {
-    const { name, domain, iconURL, uid }: RawBody<CreateSiteBodyParams> = req.body;
+    const { name, domain, iconURL }: RawBody<CreateSiteBodyParams> = req.body;
     if (typeof name !== "string" || validator.isEmpty(name)) {
         throw new CustomApiError("'name' must be a non-empty string");
     }
     if (typeof domain !== "string" || !validator.isURL(domain)) {
         throw new CustomApiError("'domain' must be a valid URL");
     }
-    if (
-        iconURL !== undefined &&
-        iconURL !== null &&
-        (typeof iconURL !== "string" || !validator.isURL(iconURL))
-    ) {
-        throw new CustomApiError("'iconURL' must be either a valid url, undefined or null");
+    if (iconURL !== null && (typeof iconURL !== "string" || !validator.isURL(iconURL))) {
+        throw new CustomApiError("'iconURL' must be either a valid url or null");
     }
-    /**
-     * I will write regex to change this later.
-     */
-    if (typeof uid !== "string" || validator.isEmpty(uid)) {
-        throw new CustomApiError("'uid' must be a non empty-string");
-    }
-    req.body = { name, domain, iconURL: iconURL ?? null, uid };
+    req.body = { name, domain, iconURL: iconURL ?? null };
     next();
 };
 

--- a/server/utils/crud/pageUtils.ts
+++ b/server/utils/crud/pageUtils.ts
@@ -10,20 +10,28 @@ import { CreatePageBodyParams, Page, Site, UpdatePageBodyParams } from "~/types/
 
 import { deletePageCommentsById } from "./commentUtils";
 
-export async function getPageById(pageId: string) {
+/**
+ * Gets the information of a page
+ *
+ * @param uid The id of the owner of the page
+ * @param pageId The id of the page
+ */
+export async function getPageById(uid: string, pageId: string) {
     try {
-        const result = await PAGES_COLLECTION.doc(pageId).get();
-        if (!result.exists) {
-            throw new CustomApiError("Page does not exist", 404);
-        }
-        return result.data() as Page;
+        const pageSnapshot = await PAGES_COLLECTION.doc(pageId).get();
+        const pageData = pageSnapshot.data() as Page;
+
+        if (!pageSnapshot.exists) throw new CustomApiError("Page does not exist", 404);
+        if (uid !== pageData.uid) throw new CustomApiError("Forbidden", 403);
+
+        return pageData;
     } catch (err) {
         handleFirestoreError(err);
     }
 }
 
 /**
- * Creates a new page
+ * Creates a new page.
  *
  * @param uid The id of the owner of the page
  * @param data The data of the page

--- a/server/utils/crud/siteUtils.ts
+++ b/server/utils/crud/siteUtils.ts
@@ -11,16 +11,19 @@ import { deleteSitePagesById } from "./pageUtils";
 /**
  * Get a site with the given id.
  *
+ * @param uid The id of the owner of this site
  * @param siteId The site's id
  * @returns The data of the site.
  */
-export async function getSiteById(siteId: string) {
+export async function getSiteById(uid: string, siteId: string) {
     try {
-        const result = await SITES_COLLECTION.doc(siteId).get();
-        if (!result.exists) {
-            throw new CustomApiError("Site does not exist", 404);
-        }
-        return result.data();
+        const siteSnapshot = await SITES_COLLECTION.doc(siteId).get();
+        const siteData = siteSnapshot.data() as Site;
+
+        if (!siteSnapshot.exists) throw new CustomApiError("Site does not exist", 404);
+        if (uid !== siteData.uid) throw new CustomApiError("Forbidden", 403);
+
+        return siteData;
     } catch (err) {
         handleFirestoreError(err);
     }

--- a/server/utils/testUtils.ts
+++ b/server/utils/testUtils.ts
@@ -24,9 +24,8 @@ function setSitesInBatch(batch: WriteBatch, sites: Site[]) {
 
 function setPagesInBatch(batch: WriteBatch, pages: Page[]) {
     for (const page of pages) {
-        const { id, siteId, name } = page;
+        const { id } = page;
         batch.set(PAGES_COLLECTION.doc(id), page);
-        batch.set(SITES_COLLECTION.doc(siteId).collection("pages").doc(name), { id });
     }
 }
 
@@ -95,8 +94,8 @@ export function createTestUser(uid: string): UserImportRecord {
  * user@(User uid id name ...)
  */
 export function createTestSite({
-    uid,
     id,
+    uid,
     name = `Site ${id}`,
     domain = `https://example${id}.com`,
     iconURL = null,
@@ -109,14 +108,15 @@ export function createTestSite({
 
 export function createTestPage({
     id,
+    uid,
     siteId,
-    name = `Page ${id}`,
+    title = `Page ${id}`,
     autoApprove = true,
     url = `https://example${siteId}.com/${id}`,
     totalCommentCount = 0,
     pendingCommentCount = 0,
-}: OnlyRequired<Page, "id" | "siteId">): Page {
-    return { id, name, url, autoApprove, totalCommentCount, pendingCommentCount, siteId };
+}: OnlyRequired<Page, "id" | "siteId" | "uid">): Page {
+    return { id, title, url, autoApprove, totalCommentCount, pendingCommentCount, uid, siteId };
 }
 
 export function createTestComment({

--- a/types/server/nextApi.type.ts
+++ b/types/server/nextApi.type.ts
@@ -56,3 +56,5 @@ export type AuthenticatedApiRequest = NextApiRequest & {
     // We shall attach the uid into the request
     user: DecodedIdToken;
 };
+
+export type AuthenticatedApiRequestWithFormData = AuthenticatedApiRequest & ApiRequestWithFormData;

--- a/types/server/nextApi.type.ts
+++ b/types/server/nextApi.type.ts
@@ -1,3 +1,4 @@
+import { DecodedIdToken } from "firebase-admin/auth";
 import { NextApiRequest, NextApiResponse } from "next";
 
 /**
@@ -51,9 +52,7 @@ export type ApiRequestWithFormData = NextApiRequest & {
     file?: FormDataFile;
 };
 
-export type AuthenticatedApiRequest = Omit<NextApiRequest, "body"> & {
-    body: {
-        uid: string;
-        [key: string]: any;
-    };
+export type AuthenticatedApiRequest = NextApiRequest & {
+    // We shall attach the uid into the request
+    user: DecodedIdToken;
 };

--- a/types/server/nextApi.type.ts
+++ b/types/server/nextApi.type.ts
@@ -50,3 +50,10 @@ export type FormDataFile = {
 export type ApiRequestWithFormData = NextApiRequest & {
     file?: FormDataFile;
 };
+
+export type AuthenticatedApiRequest = Omit<NextApiRequest, "body"> & {
+    body: {
+        uid: string;
+        [key: string]: any;
+    };
+};

--- a/types/server/page.type.ts
+++ b/types/server/page.type.ts
@@ -2,7 +2,8 @@ import { Comment } from "./comment.type";
 
 export type Page = {
     readonly id: string;
-    name: string;
+
+    title: string;
     url: string;
     autoApprove: boolean;
 
@@ -15,13 +16,13 @@ export type Page = {
 
 export type UpdatePageBodyParams = {
     url?: string;
-    name?: string;
+    title?: string;
     autoApprove?: boolean;
 };
 
 export type CreatePageBodyParams = {
     url: string;
-    name: string;
+    title: string;
     autoApprove: boolean; // default true
     siteId: string;
 };

--- a/types/server/page.type.ts
+++ b/types/server/page.type.ts
@@ -8,14 +8,9 @@ export type Page = {
 
     totalCommentCount: number;
     pendingCommentCount: number;
-    readonly siteId: string; // foreign key
-};
 
-export type CreatePagePathParams = {
-    /**
-     * The id of the site that contains this page.
-     */
-    siteId: string;
+    readonly uid: string; // foreign key
+    readonly siteId: string; // foreign key
 };
 
 export type UpdatePageBodyParams = {

--- a/types/server/site.type.ts
+++ b/types/server/site.type.ts
@@ -56,7 +56,6 @@ export type CreateSiteBodyParams = {
     name: string;
     domain: string;
     iconURL: string | null;
-    uid: string;
 };
 
 export type SiteStatistics = {


### PR DESCRIPTION
Some lines are VERY repetitive. I will refractor them later.

A few things to note:
- Fixed security problems. For the sites and pages, after decode the JWT I will attach the decoded token into the request as `req.user` (to not pollute `req.body`).
- For any CRUD operation, I will compare the `uid` in `req.user` and the `uid` stored in the document. If they are different, the request will fail. For example, if a new page is going to be created:
  - First, the site with id `siteId` will be read.
  - If the `uid` stored inside that site is different from the `uid` received from the decoded token, an error will be thrown.
- ~~I still want to include `uid` as a body param when create site. With the new implementation, I cannot create a new site with Postman to test with the emulator (as now I have no way to specify the `uid` of the owner).~~ Never mind, I figued a way to deal with this.

We will close the issues after this PR is merged.