### PR TITLE
Implement dark mode support for comment sections

### DIFF
--- a/pages/api/embed/[siteId]/[pageId].ts
+++ b/pages/api/embed/[siteId]/[pageId].ts
@@ -6,6 +6,7 @@ import { extractFirstQueryValue } from "~/server/utils/nextHandlerUtils";
 import { EmbedConfigurations } from "~/types/server/nextApi.type";
 
 const handler = ncRouter().get(async (req, res) => {
+    const { dark } = req.query;
     const { siteId, pageId } = extractFirstQueryValue(req);
     /**
      * Check whether the page exists or not.
@@ -22,7 +23,7 @@ const handler = ncRouter().get(async (req, res) => {
         postURL: `/api/comments`,
     };
     const { customisation } = await getSiteCustomisation(siteId);
-    const generatedHTML = generateCommentHTML(customisation, config);
+    const generatedHTML = generateCommentHTML(customisation, config, dark === "1");
     res.status(200).send(generatedHTML);
 });
 


### PR DESCRIPTION
> ### Dark Mode
> 
> The embed URL will have a query parameter `isDark`. If it is used, the comment is delivered in dark mode. The `<html>` element would have a class `.dark`, and of course, the user can control how their comment section looks in dark mode by modifying his `<style>` accordingly.
> 
> ```html
> <!-- /embed/:siteId/:pageId -->
> <html>
>   <!-- everything -->
> </html>
> 
> <!-- /embed/:siteId/:pageId?isDark=1 -->
> <html class="dark">
>   <!-- everything -->
> </html>
> ```

I was preparing ms3-readme when I read this part from ms2-readme. We completely forgot this.

It was quite easy to implement though. I shortened the query to `dark`.

<img width="443" alt="image" src="https://user-images.githubusercontent.com/44609036/180394631-6b648183-e0c3-4bb3-af0d-61ccdab9c3fc.png">
