### PR TITLE
Allow author field to be "" (string of length 0)

### DIFF
--- a/__tests__/misc/validate.test.ts
+++ b/__tests__/misc/validate.test.ts
@@ -76,11 +76,6 @@ describe("Test comment validation", () => {
         expect(COMMENT.textIsValid("a")).toBe(true);
         expect(COMMENT.textIsValid("a b")).toBe(true);
     });
-    it("Check authorIsValid", () => {
-        expect(COMMENT.authorIsValid("")).toBe(false);
-        expect(COMMENT.authorIsValid("a")).toBe(true);
-        expect(COMMENT.authorIsValid("a b")).toBe(true);
-    });
     it("Check pageIdIsValid", () => {
         expect(COMMENT.pageIdIsValid("")).toBe(false);
         expect(COMMENT.pageIdIsValid("a")).toBe(true);

--- a/misc/validate.ts
+++ b/misc/validate.ts
@@ -47,7 +47,6 @@ export const PAGE = {
 
 export const COMMENT = {
     textIsValid: (content: string) => content.length > 0,
-    authorIsValid: (author: string) => author.length > 0,
     // server-only
     pageIdIsValid: idIsValid,
 };

--- a/server/middlewares/sanitizeRequests/comments.ts
+++ b/server/middlewares/sanitizeRequests/comments.ts
@@ -23,7 +23,7 @@ export const sanitizeCreateCommentRequest: ApiMiddleware = (req, _, next) => {
     if (typeof pageId !== "string" || !COMMENT.pageIdIsValid(pageId)) {
         throw new CustomApiError("'pageId' must be a non-empty string");
     }
-    req.body = { author: author && (author as string).length > 0 ? author : null, text, pageId };
+    req.body = { author: author || null, text, pageId };
     next();
 };
 

--- a/server/middlewares/sanitizeRequests/comments.ts
+++ b/server/middlewares/sanitizeRequests/comments.ts
@@ -16,7 +16,7 @@ export const sanitizeCreateCommentRequest: ApiMiddleware = (req, _, next) => {
     }
     if (author !== undefined && author !== null && typeof author !== "string") {
         throw new CustomApiError(
-            "'author' must be a non-empty string, undefined or null. If undefined, 'author' will be casted to null."
+            "'author' must be a string, undefined or null. If falsy, 'author' will be casted to null."
         );
     }
     // Subject to change

--- a/server/middlewares/sanitizeRequests/comments.ts
+++ b/server/middlewares/sanitizeRequests/comments.ts
@@ -14,11 +14,7 @@ export const sanitizeCreateCommentRequest: ApiMiddleware = (req, _, next) => {
     if (typeof text !== "string" || !COMMENT.textIsValid(text)) {
         throw new CustomApiError("'text' must not be a non-empty string");
     }
-    if (
-        author !== undefined &&
-        author !== null &&
-        (typeof author !== "string" || !COMMENT.authorIsValid(author))
-    ) {
+    if (author !== undefined && author !== null && typeof author !== "string") {
         throw new CustomApiError(
             "'author' must be a non-empty string, undefined or null. If undefined, 'author' will be casted to null."
         );
@@ -27,7 +23,7 @@ export const sanitizeCreateCommentRequest: ApiMiddleware = (req, _, next) => {
     if (typeof pageId !== "string" || !COMMENT.pageIdIsValid(pageId)) {
         throw new CustomApiError("'pageId' must be a non-empty string");
     }
-    req.body = { author: author ?? null, text, pageId };
+    req.body = { author: author && (author as string).length > 0 ? author : null, text, pageId };
     next();
 };
 


### PR DESCRIPTION
I was play around with the comment pages and attempted to post some comments. However, anonymous comments cannot be submitted.

```http
POST /api/comments

{
  "author": "",
  "text": "hello, world",
  "pageId": "anything"
}
```

fails because `author` doesn't pass the check

https://github.com/joulev/ezkomment/blob/dd993cd38f448064e6e8bc491389440c411fde11/server/middlewares/sanitizeRequests/comments.ts#L17-L25

In fact since the field is taken from an HTML input field, `author` is always a string &ndash; if the user doesn't fill in then it's `""` like above.

This means the validation is buggy. This PR tries to fix it.